### PR TITLE
Add nag/warn/info skip options

### DIFF
--- a/src/emu/emuopts.h
+++ b/src/emu/emuopts.h
@@ -153,6 +153,8 @@
 #define OPTION_BIOS					"bios"
 #define OPTION_CHEAT				"cheat"
 #define OPTION_SKIP_GAMEINFO		"skip_gameinfo"
+#define OPTION_SKIP_WARNINGS		"skip_warnings"
+#define OPTION_SKIP_NAGSCREEN		"skip_nagscreen"
 
 /* image device options */
 #define OPTION_ADDED_DEVICE_OPTIONS	"added_device_options"

--- a/src/emu/machine.c
+++ b/src/emu/machine.c
@@ -394,7 +394,7 @@ int running_machine::run(bool firstrun)
 		sound_mute(this, FALSE);
 
 		// display the startup screens
-		ui_display_startup_screens(this, firstrun, !settingsloaded);
+		ui_display_startup_screens(this, firstrun, !options_get_bool(&m_options, OPTION_SKIP_NAGSCREEN));
 
 		// perform a soft reset -- this takes us to the running phase
 		soft_reset();

--- a/src/emu/ui.c
+++ b/src/emu/ui.c
@@ -279,7 +279,7 @@ int ui_display_startup_screens(running_machine *machine, int first_time, int sho
 	const int maxstate = 3;
 	int str = options_get_int(machine->options(), OPTION_SECONDS_TO_RUN);
 	int show_gameinfo = !options_get_bool(machine->options(), OPTION_SKIP_GAMEINFO);
-	int show_warnings = TRUE;
+	int show_warnings = !options_get_bool(machine->options(), OPTION_SKIP_WARNINGS);
 	int state;
 
 	/* disable everything if we are using -str for 300 or fewer seconds, or if we're the empty driver,

--- a/src/mame/machine/slikshot.c
+++ b/src/mame/machine/slikshot.c
@@ -277,8 +277,8 @@ static void vels_to_inters(UINT8 x, UINT8 vx, UINT8 vy,
 
 	/* inter2 can be derived from Vx and Vy */
 	_27d8 = ((UINT64)vy * 0xfbd3) >> 16;
-	*inter2 = 0x30f2e / (_27d8 + ((abs((INT8)vx) << 16) / 0x58f8c));
-	inter2a = 0x30f2e / (_27d8 - ((abs((INT8)vx) << 16) / 0x58f8c));
+	*inter2 = 0x30f2e / (_27d8 + (((INT8)abs((INT8)vx) << 16) / 0x58f8c));
+	inter2a = 0x30f2e / (_27d8 - (((INT8)abs((INT8)vx) << 16) / 0x58f8c));
 
 	/* compute it back both ways and pick the closer */
 	inters_to_vels(*inter1, *inter2, 0, 0, &x1, &vx1, &vy1);

--- a/src/osd/retro/retromain.c
+++ b/src/osd/retro/retromain.c
@@ -315,6 +315,18 @@ int executeGame(char* path) {
 		}
 	}
 
+	if(hide_gameinfo) {
+		xargv[paramCount++] =(char*) "-skip_gameinfo";
+	}
+
+	if(hide_nagscreen) {
+		xargv[paramCount++] =(char*) "-skip_nagscreen";
+	}
+
+	if(hide_warnings) {
+		xargv[paramCount++] =(char*) "-skip_warnings";
+	}
+
 	xargv[paramCount++] = MgameName;
 
 	write_log("executing frontend... params:%i\n", paramCount);

--- a/src/osd/retro/retromain.c
+++ b/src/osd/retro/retromain.c
@@ -40,7 +40,9 @@ char g_rom_dir[1024];
 
 static bool mouse_enable = false;
 static bool videoapproach1_enable = false;
-bool nagscreenpatch_enable = false;
+bool hide_nagscreen = false;
+bool hide_gameinfo = false;
+bool hide_warnings = false;
 
 static void extract_basename(char *buf, const char *path, size_t size)
 {

--- a/src/osd/retro/retromapper.c
+++ b/src/osd/retro/retromapper.c
@@ -43,7 +43,9 @@ void retro_set_environment(retro_environment_t cb)
    static const struct retro_variable vars[] = {
       { "mame_current_mouse_enable", "Mouse supported; disabled|enabled" },
       { "mame_current_videoapproach1_enable", "Video approach 1 Enabled; disabled|enabled" },
-      { "mame_current_nagscreenpatch_enable", "Nagscreen patch Enabled; disabled|enabled" },
+      { "mame_current_skip_nagscreen", "Hide nag screen; disabled|enabled" },
+      { "mame_current_skip_gameinfo", "Hide game info screen; disabled|enabled" },
+      { "mame_current_skip_warnings", "Hide warning screen; disabled|enabled" },
       { NULL, NULL },
    };
 
@@ -66,16 +68,40 @@ static void check_variables(void)
          mouse_enable = true;
    }
 
-   var.key = "mame_current_nagscreenpatch_enable";
+   var.key = "mame_current_skip_nagscreen";
    var.value = NULL;
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       fprintf(stderr, "value: %s\n", var.value);
       if (strcmp(var.value, "disabled") == 0)
-         nagscreenpatch_enable = false;
+         hide_nagscreen = false;
       if (strcmp(var.value, "enabled") == 0)
-         nagscreenpatch_enable = true;
+         hide_nagscreen = true;
+   }
+
+   var.key = "mame_current_skip_gameinfo";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      fprintf(stderr, "value: %s\n", var.value);
+      if (strcmp(var.value, "disabled") == 0)
+         hide_gameinfo = false;
+      if (strcmp(var.value, "enabled") == 0)
+         hide_gameinfo = true;
+   }
+
+   var.key = "mame_current_skip_warnings";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      fprintf(stderr, "value: %s\n", var.value);
+      if (strcmp(var.value, "disabled") == 0)
+         hide_warnings = false;
+      if (strcmp(var.value, "enabled") == 0)
+         hide_warnings = true;
    }
 
    var.key = "mame_current_videoapproach1_enable";


### PR DESCRIPTION
Changes in slikshot.c fix compilation on GCC6+.

I don't have a ROM set to test this against so I'll need someone to try it.