### PR TITLE
comment out RETRO_ENVIRONMENT_SHUTDOWN

### DIFF
--- a/src/osd/retro/retromapper.c
+++ b/src/osd/retro/retromapper.c
@@ -126,7 +126,7 @@ static void retro_wrap_emulator()
 
     pauseg=-1;
 
-    environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, 0); 
+//    environ_cb(RETRO_ENVIRONMENT_SHUTDOWN, 0); 
 
     // Were done here
     co_switch(mainThread);


### PR DESCRIPTION
solves the issue of the core shutting the frontend down when you try to launch another game/core. I didn't notice any regressions from it but this should probably be corroborated by others before merging.