### PR TITLE
Report git version with library_version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,11 @@ CPPONLYFLAGS =
 LDFLAGS =
 LDFLAGSEMULATOR =
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CCOMFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 # uncomment next line to build zlib as part of MAME build
 #BUILD_ZLIB = 1
 

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -2,6 +2,11 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 LOCAL_MODULE    := retro
 
 ifeq ($(TARGET_ARCH),arm)

--- a/src/osd/retro/retromapper.c
+++ b/src/osd/retro/retromapper.c
@@ -127,7 +127,10 @@ void retro_get_system_info(struct retro_system_info *info)
 {   	
    memset(info, 0, sizeof(*info));
    info->library_name = "MAME 2010";
-   info->library_version = "0.139";
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+   info->library_version = "0.139" GIT_VERSION;
    info->valid_extensions = "zip|chd|7z";
    info->need_fullpath = true;   
    info->block_extract = true;


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.