### PR TITLE
add metadata to activate cheat and highscore engines

### DIFF
--- a/metadata/cheat-origin-docs-and-credits.txt
+++ b/metadata/cheat-origin-docs-and-credits.txt
@@ -1,0 +1,6648 @@
+MAME CHEATS Release Date: 03 August 2010 (Base release for MAME 0.139)
+
+
+SECTIONS
+-======-
+
+Simple
+1.  Basic Instructions on enabling cheats in MAME
+2.  Cheat Description Meanings
+3.  Cheat Ordering
+
+Advanced
+4.  **N/A**  Cheat Engine Commands (to customise the cheat UI) **N/A**
+5.  **N/A**  Cheat Format Information **N/A**
+6.  **N/A**  How to Pre-Enable cheats **N/A**
+7.  Dynamic Cheat Finding method
+
+Credits/Lists
+8.  General Credits
+9.  Games utilising ROM cheats with credits
+10. Games utilising EEPROM/Mapped Memory cheats with credits
+11. Games utilising Forced Range cheats with credits
+12. Games utilising Dynamic (Relative Addressing) cheats with credits
+13. Games which may use the same cheats
+14. Games which currently have no cheats with reason
+
+Work to be done
+15. General list of work to be done
+
+
+------------------------------------------------------------------------------
+         SECTION 1     Basic Instructions on enabling cheats in MAME
+------------------------------------------------------------------------------
+
+What to do with the cheat.zip file :-
+
+Step 1 (what to do with the cheat.zip file )
+============================================
+
+First of all do NOT unzip the cheat.zip file - it will work just fine as a zip,
+it contains 8831 xml files so unzipping it is not advised.
+
+First of all unzip/un7z the still packed cheat.zip file into the same directory
+that contains MAME.EXE (All platforms apart from Mac OS 9/X ).
+
+For MacMAME the cheat.zip file should be in:-
+${HOME}/Documents/MacMAME User Data/Misc Support Files
+
+For MAME OS X (not SDLMAME OSX!) the cheat.zip file should be in:-
+${HOME}/Library/Application Support/MAME OS X
+
+
+Step 2 (Enable the MAME Cheat Engine)
+=====================================
+
+As standard the MAME Cheat Engine is turned OFF, there are several ways of
+turning it ON depending on which platform you are running MAME on.
+
+MAME:  This is the standard MAME command line compile, go to your MAME
+        directory open up the MAME.INI file with a text editor (the one you
+        are using to read this will probably do!).
+          Find '### Mame CORE misc options ###' and change 'cheat 0' to
+        'cheat 1'. If you have no INI file then just start MAME from the
+        command-line with the -createconfig option  eg. 'MAME -createconfig'.
+        If you manually use MAME every time from the command-line you can also
+        just add '-cheat' to the command line.
+
+MAMEUI: This is the MAME with build in frontend compile for Windows. Go to
+        the Options Menu, and select "Default Options". Go to the
+        Miscellaneous tab and check the box that says "Enable Game Cheats".
+
+DMAME:  This is the DOS MAME compile, go to your MAME directory open up the
+        MAME.CFG file with a text editor (the one you are using to read this
+        will probably do!).
+          Find 'cheat off' and change it to 'cheat on'. If you have no CFG file
+        then just start MAME from the command-line with the -createconfig
+        option eg. 'MAME -createconfig'. If you manually use MAME every time
+        from the command-line you can also just add '-cheat' to the
+        command-line.
+
+UNIX:   For the UNIX/LINUX compiles just follow the instructions for DMAME
+        the DOS compile.
+
+OS9/X:  From the front-end, go to the Misc tab, and check the box that says
+        "Allow Cheats".
+
+
+Step 3 (Cheat!)
+===============
+
+In-game press TAB and follow your nose......
+Left and Right cursor toggles cheats ON and OFF, ENTER turns on one shot cheats
+and SPACE displays the cheat comments if there are any (the comments will auto
+display as you move up/down to a cheat with any comments for a short time).
+
+
+------------------------------------------------------------------------------
+                 SECTION 2     Cheat Description Meanings
+------------------------------------------------------------------------------
+
+GENERAL NOTES ABOUT CHEAT DESCRIPTIONS AND WHAT THEY MEAN:
+----------------------------------------------------------
+NOTES: The cheat descriptions use the following terms, this is what they
+       actually mean:
+
+Get+Now! means the cheat is a type 00000001 cheat and so it is a temporary cheat -
+         it changes the memory and then deactivates. Type 01 is ideal for
+         getting a particular weapon or feature, also needed for a Finish
+         Level Now! cheat.
+
+Always   means the cheat is permanent (several cheat types) idea for always
+         having a certain weapon or feature eg always have 3 rainbows on
+         Rainbow Islands.
+
+Infinite means exactly what it says - you will have an inexhaustible supply of
+         the named item be it lives, time, ammo or something else. On some
+         rare occasions you may need to deactivate the cheat before you can
+         finish a level, if this need to be done you will see F6 at the end
+         of the cheat description.
+
+Select current level  - Select a level and you can progress to it by losing a
+                        life. You should only activate this type of cheat
+                        during game play or according to the comments.
+
+Select next level - Select a level and when you complete the current level you
+                    will progress straight to the selected level. You can also
+                    activate this on the title/attract screens though the
+                    effects cannot always be guaranteed! (you will either
+                    start on the selected level or the next level after the
+                    selected one or level 1). A far better method if you want
+                    to select the starting level from the title screen is to
+                    use the method that I thought of for Metrocross. See
+                    Metrocross remarks for info.
+
+Select Score - This cheat allows you to select your score or/and the other
+               player's score, ideal for sports games where you need a certain
+               score to win and/or progress. It must ONLY be activated during
+               game play. Also note the score may not display correctly until
+               the score has changed properly!
+
+
+------------------------------------------------------------------------------
+                       SECTION 3     Cheat Ordering
+------------------------------------------------------------------------------
+
+This is how I order the cheats - I try and stick to it as often as I can.
+Some games don't conform to this standard either because it's better as is or
+the cheats were done a while ago and I haven't changed them. DO NOT report any
+games that don't follow this standard - it's pretty low on the list of
+priorities right now.
+
+OVERALL CHEAT ORDER
+-------------------
+
+gamename in format '; [ long game name ]'
+section1
+section2
+section3 (if applicable)
+section4
+
+WHAT'S EACH SECTION ABOUT?
+--------------------------
+
+Section 1 contains all the cheats valid for all players. Infinite Credits will
+come first normally.
+
+Section 2 contains cheats for individual players, split up so that all PL1
+cheats are together and all PL2 cheats are together. Normally there will be the
+same cheats for each player and the order of the cheats should be the same as
+for the other player.
+
+Section 3 contains cheats that are hard to button-hole and have fairly obscure
+effects on the game that only the die-hard player of that game may really want.
+These sort of cheats can often be merged into section 2, though in some
+circumstances the sheer number of these cheats will seriously clutter out the
+normal everyday cheats (section 2). In that case they should be separated into
+another section and the PL1 / PL2 separation in that section should be maintained
+if possible.
+
+Section 4 contains any none cheat related things. Eg. Sound test timer and region
+switch  codes.
+
+WHAT'S IN EACH SECTION
+----------------------
+
+The normal order of cheats will be if there is no PL1 or PL2 specific cheats.
+If a cheat is specific to all players it will promote it up the list.
+
+Infinite Credits
+Infinite Time       (if 'Finish this Round Now!' is worthwhile it should
+                     directly follow this cheat)
+Infinite Lives
+Infinite Energy     (if 'Drain all Energy Now!' is worthwhile it should
+                     directly follow this cheat)
+Infinite Ammo
+Infinite Bombs
+Invincibility       (if Invincibility doesn't turn off after a short while of
+                     disabling it then there should be separate 'ON' and 'OFF'
+                     cheats)
+Always have this weapon
+Get this weapon Now!
+Play with this character Now!
+Select starting level
+Select current level
+Select next level
+
+SPACING/BLANK COMMENTS
+----------------------
+
+Blank Comment cheats should be added to improve the readability of the cheats
+in the cheat engine were appropriate.
+
+There should be a blank after section 1 if section 2 has 3 or more cheat entries
+for each player OR if section 1 has itself got three or more cheat entries.
+
+If there are 3 or more cheat entries for each player in section 2 then the
+entries for each player should be seperated with a blank comment.
+
+If section 3 exists it should ideally be preceded by a blank comment.
+
+If section 4 exists it should ideally be preceded by a blank comment.
+
+
+------------------------------------------------------------------------------
+        SECTION 4     Cheat Engine Commands (to customise the cheat UI)
+------------------------------------------------------------------------------
+
+The cheat engine has recently been radically changed, this section is
+currently no longer applicable.
+
+------------------------------------------------------------------------------
+                  SECTION 5     Cheat Format Information
+------------------------------------------------------------------------------
+
+The cheat engine has recently been radically changed, the cheat format that was
+here is no longer applicable. Information about the new format will follow some
+time in the future.
+
+------------------------------------------------------------------------------
+              SECTION 6     How to Pre-Enable cheats
+------------------------------------------------------------------------------
+
+The cheat engine has recently been radically changed, the method that was given
+here is no longer applicable. Stay tuned for the new method (which should be
+a LOT easier).
+
+------------------------------------------------------------------------------
+                   SECTION 7     Dynamic Cheat Finding method
+------------------------------------------------------------------------------
+
+Dynamic Cheat Finding method by Pugsy
+-------------------------------------
+
+From the start, this is presuming you are using a debug MAME. I'm using samsho2
+as an example and I am looking for infinite energy for PL1 - the method is easy
+to alter for different games and/or other things (this is mainly a method used
+for neogeo games - the only real system that utilises dynamic addressing for
+'useful' locations). It's not a method for beginners, it assumes cheat finding
+skills, a basic understanding of hexadecimal addressing and an ability to
+decode my waffling.
+
+
+1. Start MAME as you would normally - don't forget you must use the debug MAME
+   build with either -debug on the command-line or DEBUG 1 in the ini file.
+
+2. You will find that after a short while MAME will be on the debugger screen,
+   at this stage just press F12 to start the game. [REMEMBER F12 in the
+   debugger will return you to the game]
+
+3. Commence play
+
+4. Start a Energy Search and reduce the results using standard methods. In the
+   example I reduced the results to 2 possibles 100AC6 & 10373B, by using
+   watches I can discount 100AC6 as it's the time location. So that leaves us
+   with 10373B 80 = Full Energy. NOTE: You have to find the value as quickly as
+   possible because the location will change the next time the level changes,
+   so you would have to start the search from the beginning. You can test the
+   address you find by poking it directly if it's the correct location you will
+   find it will have the desired affect on that level.
+
+5. Press the tilde key (the tilde key is the key under Esc and about TAB and
+   the the left of 1). You will now be in the debugger, remember the fact that
+   we found the address 0010373B in step 4 (Note the preceding 0s - we will
+   need them).
+
+6. Press TAB 3 times so that the cursor is in the address window. Now press S
+   to commence a search and type in the value as per step 5...but drop the last
+   byte as that will be part of the index. So in this case we would type in 00
+   10 37, then press RETURN to execute the search - you can repeat the search
+   by  pressing S and hitting RETURN (the last search values are still set).
+   For every search result note down the address, you can safely ignore any
+   results in ROM locations or where it crosses word boundaries (ie. it shows as
+   XX00 1037 instead of 0010 37XX). In this example you will find that
+   S 00 10 37  only returns one ROM location at 00003680, so we can safely
+   ignore it. However, there are no other occurrences so we are goosed.....or
+   are we?
+
+7. If there are no possibilities then remember that the location we are looking
+   for contains an address that hopefully points to a page of memory limited in
+   size. In most cases this seems to be no greater than 256 bytes and is mostly
+   forward indexed (+ve rather than -ve). So assuming that 10373B is the
+   extreme case it is 256 bytes away from the start of the memory page base
+   location, then the base location of the page would be 10363C. So we need to
+   repeat Step 6 but this time with S 00 10 36 as the search instruction,
+   ignoring ROM locations and word boundary crossing, from this we get the
+   following results:-
+
+   Address     Contents
+   100A46       00103680
+   100A5E       00103680
+   102AEC       00103680
+   102D2C       00103680
+   103F2C       00103680
+   10404C       00103680
+   104DCC       00103680
+   10500C       00103680
+   1057EC       00103680
+   105A2C       00103680
+   105C6C       00103680
+   10644C       00103680
+
+8. From the Step 7 results you can see that all the results point to a page of
+   memory starting at 00103680, since we know the energy location is 0010373B
+   we can work out that the index value is = BB (Cheat Location - Start Address
+   of page = 10373B -103680).
+
+9. Now you need to narrow the location down either by loads of watches on
+   several levels or by excessive testing, personally I place a watch on all
+   the locations and try the first location first, second location second etc
+   etc. [ NOTE: A lot of neogeo games which utilise dynamic addressing seem to
+   like to use a value in the range 100AXX as the pointer location. ] Here are
+   the cheats to try first...
+
+   :samsho2:83000000:00100A46:00000080:000000BB:Infinite Energy PL1 [POSSIBILITY NO. 1]
+   :samsho2:83000000:00100A5E:00000080:000000BB:Infinite Energy PL1 [POSSIBILITY NO. 2]
+   :samsho2:83000000:00102AEC:00000080:000000BB:Infinite Energy PL1 [POSSIBILITY NO. 3]
+   :samsho2:83000000:00102D2C:00000080:000000BB:Infinite Energy PL1 [POSSIBILITY NO. 4]
+
+   { One more interesting thing to note, you may find that several locations
+     will have the desired affect as the pointers maybe held in several places
+     in memory, it really doesn't matter which one you use. }
+
+10. Once you find out the location which works bear in mind that the game will
+    use the same page for other things like Power etc, Note PL2 will generally
+    use a different page though the location holding the pointer is generally
+    right next to the pointer for the other Player (the index will generally be
+    the same though...which is nice :) ).
+
+For samsho2 we hence have these dynamic cheats:-
+
+:samsho2:83000000:00100A46:00000080:000000BB:Infinite Energy PL1
+:samsho2:83000001:00100A46:00000000:000000BB:Drain All Energy Now! PL1
+:samsho2:83000000:00100A46:00000020:000000F0:Always have Maximum Power PL1
+:samsho2:83000000:00100A46:00000000:000000F0:Always have Minimum Power PL1
+:samsho2:83000000:00100A4A:00000080:000000BB:Infinite Energy PL2
+:samsho2:83000001:00100A4A:00000000:000000BB:Drain All Energy Now! PL2
+:samsho2:83000000:00100A4A:00000020:000000F0:Always have Maximum Power PL2
+:samsho2:83000000:00100A4A:00000000:000000F0:Always have Minimum Power PL2
+
+Dynamic Cheat Finding Method (c) Pugsy 2000-2002
+
+
+
+------------------------------------------------------------------------------
+                      SECTION 8     General Credits
+------------------------------------------------------------------------------
+
+The following people have contributed cheats to this cheat file since it's
+first release in early 1998. By contributing I mean they have either emailed
+me the cheats or have posted cheats on the cheat forums or have even just
+pointed out errors with the cheat file. The names are sorted alphabetically
+by first name, I prefer real names but aliases are included:
+
+Andrea Quagliarini (aka asper),
+Andresb,
+Angel L. Fradejas,
+aycaramba,
+Ben Jos Walbeehm,
+bmn,
+C-TYPE,
+Cal,
+Chris Aruffo,
+Chris Henry,
+Chuck Livingston,
+Coyotepaw,
+CyberTaco,
+Daniel Clegg,
+Daniel Donoghue,
+Darkfantager,
+Dave Haywood (aka Haze),
+David Jumper,
+Deb,
+Deckrine,
+Don Hodges (aka PhantomDJ),
+Doug Works,
+dragon2snow,
+drivium,
+Dude,
+Eli Flores,
+EmuZoneAD,
+enaitzjga,
+Eric King,
+F. D. Vorck,
+Federico Stein,
+Felipe de Almeida Leme,
+FerJoe,
+Filipe de V. Estima (aka Bugfinder),
+Franck Charron,
+Freegamer,
+From A Distance,
+Gmitra,
+Heihachi_73,
+Heiko Herold (aka Hman),
+Iain Odlin,
+Ian Patterson (the programmer of the new MAME Cheat Engine - what a great job he made of it too),
+Jaguar,
+James Henstridge,
+Jamie,
+jAsOn,
+JCK of the Ultimate Patchers (lots and lots....possible alter-ego of Steph),
+jdurgi,
+Jeff Gerstmann (aka Gleemonex),
+Joe Ho,
+John Sensebe,
+Jon Attree,
+Jon Colverson,
+Jos' Miguel Aunin Juan,
+Joseph Rard,
+Jym,
+Kelvin Chung (aka kelvSYC) {he likes his fighters far too much to be healthy! ;-P },
+Ken Lui,
+Kenshiroh,
+Kevin Butler,
+Kim Scarborough,
+KiwI_SLT,
+Kralicek,
+Kranser,
+Laurence Pittenger,
+Leo,
+Lloyd Hannesson,
+Lone Soldier,
+Luca G. Nieddu,
+Luigi,
+Lurendrejer,
+M'Lord Sandwich,
+M.A.S.H. (Multiple Arcade Special Helper) alias Xgebken,
+Mac Lak (neogeo cheats and author of the defunct CheckCDB cheat checker),
+Marc Lafontaine (the programmer of the original MAME cheat engine)
+Marc Sira,
+Marceau Mallard,
+Marcovich,
+Martin Fernandez,
+Martin Pugh ( aka Pugsy, you wouldn't believe how MANY cheats this bloke has found!!! - oh that's me! ;-) ),
+Maurizio Zanello,
+Michael Horton (alias Just Michael),
+Michel Colman,
+Mike Haggar (he of the FinalBurn & Nebula cheat files)
+mike myers,
+Mohsin,
+MRG,
+MRMIdAS,
+Nate,
+Nathan Duran,
+Nathaniel Fedewa,
+Neorage,
+NotAGoodName,
+nyc7398,
+Pablo Fernandez (AKA Darksoft),
+PAC-MAD/Doctor Flip of the Ultimate Patchers,
+Paul Priest (aka Tourniquet),
+Paul Slabowski,
+Paulo Cordeiro,
+Pon,
+Radiohead,
+Red,
+RedBeam,
+Riaan Prinsloo,
+Robert J Baker,
+Robert MacCarthy (aka Crashtest),
+Rodney Norton (aka Slade),
+RON024,
+Santeri Saarimaa,
+Seeker2002,
+SFJake,
+Sgt Capcom,
+ShimaPong aka 'The Destroyer of the cheat.dat Cheat Engine',
+Shun,
+Southpaw,
+SSJVegeta (aka  Eiji),
+Steph Humbert of the Ultimate Patchers (lots and lots),
+Sum,
+T L Hawkins,
+Tafoid (lots of "Sound Test" cheats),
+Taucher0815,
+Techno_Vamp,
+Tetrisguy,
+The Gizmo,
+The Rabbit,
+The StarCreator,
+The tECHIDNA,
+Thierry Jaboeuf,
+Thorwak,
+Tom,
+Tyler Weems,
+Udirnel,
+Valentino Georgiou,
+VisitntX,
+Voodoo666,
+Walk,
+walterh78,
+Wayder,
+Whipon,
+Who Wants to Know?,
+WhosAsking,
+Xavier,
+Yip Ho Fan,
+YMI,
+Yuuki-chan,
+Zakriya Aleem (aka zakria),
+Zan Hsieh,
+Zanic.
+
+If I've missed anybody out or if you are included twice (real name and alias)
+then please let me know. You could even send some cheats along with the info,
+I haven't heard from some of you for ages!!!
+
+------------------------------------------------------------------------------
+             SECTION 9     Games utilising ROM cheats with credits
+------------------------------------------------------------------------------
+
+Games utilising ROM cheats, where the cheat actually changes the program code
+rather than the game data. Individual credits will be given due to the extra
+work and skill - though only for cheats where RAM cheats are either not
+possible or buggy! Sometimes it is actually a LOT quicker to make a ROM hack
+than find a RAM cheat.
+
+I'm keeping this list as I may find it useful to for testing purposes when the
+cheat engine changes...especially for processors with endian (big and little)
+issues. As new clones are added I will add the cheats and give credit to the
+original author for the clones as long as the conversions are relatively
+straightforward.
+
+005 (made by ShimaPong) [Z80]
+1943 (made by ShimaPong) [Z80]
+1943j (made by ShimaPong) [Z80]
+1943kai (made by ShimaPong) [Z80]
+1943u (made by ShimaPong) [Z80]
+2020bb (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+2020bba (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+2020bbh (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+280zzzap (made by ShimaPong) [8080]
+3countb (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+3wonders (made by RedBeam) [68000]
+3wondersu (made by RedBeam) [68000]
+4dwarrio (made by ShimaPong) [Z80]
+4in1 (made by Pugsy/ShimaPong (Invincibility) & ugetab (Speed Hack)) [Z80]
+600 (made by ShimaPong) [Z80]
+800fath (made by Pugsy) [Z80]
+99lstwar (made by Shimapong) [Z80]
+99lstwara (made by Shimapong) [Z80]
+99lstwark (made by Shimapong) [Z80]
+abattle (made by ShimaPong) [M6502]
+abattle2 (made by ShimaPong) [M6502]
+abscam (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+acombat (made by ShimaPong) [M6502]
+acombato (made by ShimaPong) [M6502]
+acrobatm (made by ShimaPong) [68000]
+ad2083 (made by ShimaPong) [Z80]
+aeroboto (made by ShimaPong) [M6809]
+afire (made by ShimaPong) [M6502]
+airwolf (made by ShimaPong) [Z80]
+airwolfa (made by ShimaPong) [Z80]
+ajax (made by ShimaPong) [KONAMI]
+ajaxj (made by ShimaPong) [KONAMI]
+akkanvdr (made by Tourniquet(Region Code)) [68EC020]
+aladbl (made by Pugsy) [68000]
+alcon (made by ShimaPong) [Z80]
+alibaba (made by ShimaPong) [Z80]
+alien3 (made by ShimaPong) [V60]
+alien3u (made by ShimaPong) [V60]
+alieninv (made by Pugsy) [8080]
+alieninvp2 (made by Pugsy) [8080]
+aliensec (made by ShimaPong) [M6809]
+alpha1v (made by Pugsy) [Z80]
+alphaho (made by Pugsy) [Z80]
+alpham2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+alphamis (made by ShimaPong) [Z80]
+altair (made by Pugsy) [CDP1802]
+altbeast (made by Pugsy) [68000]
+altbeast2 (made by Pugsy) [68000]
+altbeast4 (made by Pugsy) [68000]
+altbeast5 (made by Pugsy) [68000]
+altbeastj (made by Pugsy) [68000]
+altbeastj3 (made by Pugsy) [68000]
+amatelas (updated by ShimaPong) [68000]
+amazon (updated by ShimaPong) [68000]
+ambush (made by ShimaPong) [Z80]
+ambushj (made by ShimaPong) [Z80]
+ambushv (made by ShimaPong) [Z80]
+androdun (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+androdun (made by ShimaPong) [68000]
+angelkds (made by ShimaPong) [Z80]
+anteater (made by Pugsy) [Z80]
+anteatg (made by Pugsy) [Z80]
+anteatgb (made by Pugsy) [Z80]
+aodk (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+aof (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+aof2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+aof2 (made by ShimaPong) [68000]
+aof2a (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+aof2a (made by ShimaPong) [68000]
+aof3 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+aof3k (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+aponow (made by Pugsy & Jym) [Z80]
+arabian (made by ShimaPong) [Z80]
+arabiana (made by ShimaPong) [Z80]
+arabianm (made by Tourniquet(Region Code)) [68EC020]
+arabianmj (made by Tourniquet(Region Code)) [68EC020]
+arabianmu (made by Tourniquet(Region Code)) [68EC020]
+aracnis (updated/fixed by ShimaPong) [Z80]
+arcadia (made by Pugsy) [M6809]
+argus (made by ShimaPong) [Z80]
+arian (made by ShimaPong) [Z80]
+arkretrn (made by Tourniquet(Region Code)) [68EC020]
+armedf (made by ShimaPong) [68000]
+armedff (made by ShimaPong) [68000]
+armora (made by Pugsy) [CCPU]
+armorap (made by Pugsy) [CCPU]
+armorar (made by Pugsy) [CCPU]
+armorcar (made by ShimaPong) [Z80]
+armorcar2 (made by ShimaPong) [Z80]
+ar_sdwr (made by ShimaPong) [68000]
+ar_sdwr2 (made by ShimaPong) [68000]
+ar_xeon (made by ShimaPong) [68000]
+aso (made by ShimaPong) [Z80]
+assault (made by ShimaPong) [68000]
+assaultj (made by ShimaPong) [68000]
+assaultp (made by ShimaPong) [68000]
+astdelux (made by Pugsy) [M6502]
+astdelux1 (made by Pugsy) [M6502]
+astdelux2 (made by Pugsy) [M6502]
+asterix (made by ShimaPong) [68000]
+asterixaad (made by ShimaPong) [68000]
+asterixeaa (made by ShimaPong) [68000]
+asterixeac (made by ShimaPong) [68000]
+asterixj (made by ShimaPong) [68000]
+asterock (made by Pugsy) [M6502]
+asteroid (made by Pugsy) [M6502]
+asteroid1 (made by Pugsy) [M6502]
+asteroid2 (made by Pugsy) [M6502]
+asteroidb (made by Pugsy) [M6502]
+astrob (updated/fixed by ShimaPong) [Z80]
+astrob1 (updated/fixed by ShimaPong) [Z80]
+astrob2 (updated/fixed by ShimaPong) [Z80]
+astrob2a (updated/fixed by ShimaPong) [Z80]
+astrobg (updated/fixed by ShimaPong) [Z80]
+astrof (made by ShimaPong) [M6502]
+astrof2 (made by ShimaPong) [M6502]
+astrof3 (made by ShimaPong) [M6502]
+astrofl (made by ShimaPong) [Z80]
+athena (made by ShimaPong) [Z80]
+atlantis (made by ShimaPong) [Z80]
+atlantis2 (made by ShimaPong) [Z80]
+atlantisb (made by ShimaPong) [Z80]
+atomboy (made by Pugsy) [Z80]
+atomboya (made by Pugsy) [Z80]
+aurail (made by ShimaPong) [68000]
+aurail1 (made by ShimaPong) [68000]
+aurailj (made by ShimaPong) [68000]
+azurian (updated/fixed by ShimaPong) [Z80]
+backfirt (made by Pugsy) [Z80]
+bakatono (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ballbomb (made by ShimaPong) [8080]
+baluba (made by ShimaPong) [Z80]
+bangbead (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+bankp (made by ShimaPong) [Z80]
+baraduke (made by ShimaPong) [M6809]
+barricad (made by Pugsy) [I8080]
+barrier (made by Pugsy) [CCPU]
+batman2 (made by Pugsy) [Z80]
+battlane (made by Pugsy) [M6809]
+battlane2 (made by Pugsy) [M6809]
+battlane3 (made by Pugsy) [M6809]
+battles (made by ShimaPong) [Z80]
+battlex (updated/fixed by ShimaPong) [Z80]
+battlnts (made by ShimaPong) [HD6309]
+battlntsj (made by ShimaPong) [HD6309]
+bbbxing (made by RedBeam) [V70]
+bchopper (made by ShimaPong) [V30]
+bcruzm12 (made by ShimaPong) [Z80]
+beaminv (made by ShimaPong) [Z80]
+beaminva (made by ShimaPong) [Z80]
+beastf (made by ShimaPong) [Z80]
+beezer (made by Pugsy) [M6809]
+beezer1 (made by Pugsy) [M6809]
+berenstn (made by Pugsy) [M6502]
+berzerk (made by ShimaPong) [Z80]
+berzerk1 (made by ShimaPong) [Z80]
+berzerkg (made by ShimaPong) [Z80]
+bigkong (made by aycaramba {Invincibility/level} & PhantomDJ {Kill Screen Fix}) [Z80]
+bioatack (made by ShimaPong) [Z80]
+biomtoy (made by Pugsy) [68000]
+bionicc (made by ShimaPong) [68000]
+bionicc1 (made by ShimaPong) [68000]
+bionicc2 (made by ShimaPong) [68000]
+bjourney (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+black (made by Pugsy) [Z80]
+blasto (made by Pugsy) [8080]
+blastoff (made by ShimaPong) [M6809]
+blazlaz (made by Pugsy) [HuC6280]
+blazstar (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+blckgalb (made by ShimaPong) [Z80]
+blitz (made by Pugsy) [R5000]
+blitz11 (made by Pugsy) [R5000]
+blitz2k (made by Pugsy) [R5000]
+blitz99 (made by Pugsy) [R5000]
+blkbustr (made by ShimaPong) [Z80]
+blkhole (made by ugetab) [Z80]
+blockcar (made by RedBeam) [68000]
+blockgal (made by ShimaPong) [Z80]
+blockout (made by RedBeam) [68000]
+blockout2 (made by RedBeam) [68000]
+blockoutj (made by RedBeam) [68000]
+blueprnt (made by ShimaPong) [Z80]
+blueprntj (made by ShimaPong) [Z80]
+bnj (made by ShimaPong) [M6502]
+boggy84 (made by ShimaPong) [Z80]
+boggy84b (made by ShimaPong) [Z80]
+bombsa (made by ShimaPong) [Z80]
+bonzeadv (made by Pugsy) [68000]
+bonzeadvo (made by Pugsy) [68000]
+bonzeadvu (made by Pugsy) [68000]
+boomrana (made by Pugsy) [DECO CPU16]
+boomrang (made by Pugsy) [DECO CPU16]
+bosco (made by Pugsy) [Z80]
+boscomd (made by Pugsy) [Z80]
+boscomdo (made by Pugsy) [Z80]
+boscoo (made by Pugsy) [Z80]
+boscoo2 (made by Pugsy) [Z80]
+botanic (made by ShimaPong) [Z80]
+bounty (made by ShimaPong) [Z80]
+boxingb (made by Pugsy) [CCPU]
+brain (made by ShimaPong) [Z80]
+brdrlinb (made by ShimaPong) [Z80]
+brdrline (made by ShimaPong) [Z80]
+brdrlins (made by ShimaPong) [Z80]
+breakers (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+breakrev (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+brickyrd (made by Pugsy) [I8080]
+brkthru (made by ShimaPong) [M6809]
+brkthruj (made by ShimaPong) [M6809]
+brod (made by Pugsy) [Z80]
+brubber (made by ShimaPong) [M6502]
+bstars (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+bstars2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+bstarsh (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+btime (originally made by Pugsy/replaced with Music Fixed ones made by Shimapong) [M6502]
+btime2 (originally made by Pugsy/replaced with Music Fixed ones made by Shimapong) [M6502]
+btimem (originally made by Pugsy/replaced with Music Fixed ones made by Shimapong) [M6502]
+btlecity (made by ShimaPong) [N2A03]
+bubblem (made by Tourniquet(Region Code)) [68EC020]
+bubblemj (made by Tourniquet(Region Code)) [68EC020]
+bubbobl2 (made by ShimaPong) [68EC020]
+bublbob2 (made by Tourniquet(Region Code)) [68EC020]
+bubsymphe (made by ShimaPong) [68EC020]
+bubsymphj (made by ShimaPong) [68EC020]
+bubsymphu (made by ShimaPong) [68EC020]
+buckrog (made by ShimaPong) [Z80]
+buckrogn (made by ShimaPong) [Z80]
+buggyboyjr (made by Pugsy) [8086]
+burningf (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+burningh (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+bwidow (made by Pugsy) [M6502]
+bwings (made by ShimaPong) [M6809]
+bwingsa (made by ShimaPong) [M6809]
+bwingso (made by ShimaPong) [M6809]
+bzone (made by Pugsy) [M6502]
+bzone2 (made by Pugsy) [M6502]
+bzonec (made by Pugsy) [M6502]
+cabal (made by ShimaPong) [68000]
+cabala (made by ShimaPong) [68000]
+cabalbl (made by ShimaPong) [68000]
+cabalbl2 (made by ShimaPong) [68000]
+cabalus (made by ShimaPong) [68000]
+cabalus2 (made by ShimaPong) [68000]
+calibr50 (made by Pugsy) [68000]
+calorie (made by Pugsy) [Z80]
+calorieb (made by Pugsy) [Z80]
+candance (made by Pugsy) [ARM]
+canvas (made by ShimaPong) [Z80]
+capitol (made by Pugsy) [8085A]
+caractn (made by ShimaPong) [M6502]
+castfant (made by ShimaPong) [M6502]
+caterplr (made by Pugsy) [M6502]
+catnmous (made by ShimaPong) [S2650]
+catnmousa (made by ShimaPong) [S2650]
+cavelon (made by Pugsy) [Z80]
+cbaj (made by Pugsy) [PSX CPU]
+cbdash (made by ShimaPong) [M6502]
+cbnj (made by ShimaPong) [M6502]
+cbtime (made by Pugsy) [M6502]
+cburnrub (made by ShimaPong) [M6502]
+cburnrub2 (made by ShimaPong) [M6502]
+ccboot (made by Pugsy) [Z80]
+ccboot2 (made by Pugsy) [Z80]
+cclimber (made by Pugsy) [Z80]
+cclimberj (made by Pugsy) [Z80]
+centipdb (made by Pugsy) [M6502]
+centiped (made by Pugsy) [M6502]
+centiped2 (made by Pugsy) [M6502]
+centtime (made by Pugsy) [M6502]
+cflyball (made by ShimaPong) [M6502]
+cgraplop (made by ShimaPong) [M6502]
+cgraplop2 (made by ShimaPong) [M6502]
+chaknpop (made by ShimaPong) [Z80]
+challeng (made by Pugsy) [M6502]
+cham24 {03. Mario Bros 2} (made by Pugsy) [N2A03]
+cham24 {05. Legedry (The Legend of Kage)} (made by Pugsy) [N2A03]  [NOT WORKING]
+cham24 {07. Exerion} (made by Pugsy) [N2A03]
+cham24 {08. Front Line} (made by Pugsy) [N2A03]
+cham24 {11. Islander (Wonder Boy)} (made by Pugsy) [N2A03]
+cham24 {12. Nuts & Milk} (made by Pugsy) [N2A03]
+cham24 {13. Pac-man} (based on NES code by megaman_exe) [N2A03]
+cham24 {15. Dig Dug} (made by Pugsy) [N2A03]
+cham24 {16. Pooyan} (made by Pugsy) [N2A03]
+cham24 {17. Twin Bee} (based on NES codes by Whipon) [N2A03]
+cham24 {18. Donkey Kong} (made by Pugsy) [N2A03]
+cham24 {20. Galaxian} (made by Pugsy) [N2A03]
+cham24 {21. Star Force} (made by Pugsy) [N2A03]
+cham24 {22. Xevious} (made by Pugsy) [N2A03]
+cham24 {23. Galaga} (made by Pugsy) [N2A03]
+chameleo (made by Pugsy) [M6502]
+cheesech (made by ShimaPong) [68000]
+chelnov (made by ShimaPong) [68000]
+chelnovj (made by ShimaPong) [68000]
+chelnovu (made by ShimaPong) [68000]
+chinagat (made by ShimaPong) [HD6309]
+chinhero (made by ShimaPong) [Z80]
+chinhero2 (made by ShimaPong) [Z80]
+chinherot (made by ShimaPong) [Z80]
+choko (made by Pugsy) [68000]
+chwy (made by ShimaPong) [M6502]
+circusc (made by Pugsy) [M6809]
+circusc2 (made by Pugsy) [M6809]
+circusc3 (made by Pugsy) [M6809]
+circuscc (made by Pugsy) [M6809]
+circusce (made by Pugsy) [M6809]
+citycon (made by Pugsy) [M6809]
+citycona (made by Pugsy) [M6809]
+ckong (made by aycaramba {Invincibility/level} & PhantomDJ {Kill Screen Fix}) [Z80]
+ckongalc (made by aycaramba {Invincibility/level} & PhantomDJ {Kill Screen Fix}) [Z80]
+ckongg (made by aycaramba {Invincibility/level} & PhantomDJ {Kill Screen Fix}) [Z80]
+ckongmc (made by aycaramba {Invincibility/level} & PhantomDJ {Kill Screen Fix}) [Z80]
+ckongo (made by aycaramba {Invincibility/level} & PhantomDJ {Kill Screen Fix}) [Z80]
+ckongpt2 (made by aycaramba {Invincibility/level} & PhantomDJ {Kill Screen Fix}) [Z80]
+ckongpt2a (made by aycaramba {Invincibility/level} & PhantomDJ {Kill Screen Fix}) [Z80]
+ckongpt2b (made by aycaramba {Invincibility/level} & PhantomDJ {Kill Screen Fix}) [Z80]
+ckongpt2jeu (made by aycaramba {Invincibility/level} & PhantomDJ {Kill Screen Fix}) [Z80]
+ckongs (made by aycaramba {Invincibility/level} & PhantomDJ {Kill Screen Fix}) [Z80]
+cleopatr (made by Tourniquet(Region Code)) [68EC020]
+clshroad (made by ShimaPong) [Z80]
+clshroads (made by ShimaPong) [Z80]
+cluclu (made by Pugsy) [N2A03]
+cmissnx (made by ShimaPong) [M6502]
+cnightst (made by ShimaPong) [M6502]
+cnightst2 (made by ShimaPong) [M6502]
+cobracom (made by Pugsy) [M6809]
+cobracomj (made by Pugsy) [M6809]
+commsega (made by Pugsy) [Z80]
+complexx (made by Pugsy) [M6809]
+condor (made by Pugsy) [8085A]
+cookrace (originally made by Pugsy/replaced with Music Fixed ones made by Shimapong) [M6502]
+cop01 (made by ShimaPong) [Z80]
+cop01a (made by ShimaPong) [Z80]
+cosmccop (made by Pugsy(objects)/improved by ShimaPong(scenery)) [V30]
+cosmicg (made by Pugsy) [TMS9980A/TMS9981]
+cosmicm2 (made byb Pugsy) [8080]
+cosmicmo (made by Pugsy) [8080]
+cosmo (made by Pugsy) [8080]
+cottong (made by ShimaPong) [Z80]
+countrun (made by ShimaPong) [Z80]
+countrunb (made by ShimaPong) [Z80]
+countrunb2 (made by ShimaPong) [Z80]
+cppicf (made by Pugsy) [M6502]
+cppicf2 (made by Pugsy) [M6502]
+crash (made by Pugsy) [M6502]
+crazyblk (made by ShimaPong) [Z80]
+crazywar (made by Pugsy) [E1-32N]
+crsword (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+crsword (made by ShimaPong) [68000]
+cruisin (made by Pugsy) [M6809]
+crush (made by ShimaPong) [Z80]
+crush2 (made by ShimaPong) [Z80]
+crush3 (made by ShimaPong) [Z80]
+crush4 (made by ShimaPong) [Z80]
+crushbl (made by ShimaPong) [Z80]
+crushbl2 (made by ShimaPong) [Z80]
+crushs (made by ShimaPong) [Z80]
+crzrally (made by ShimaPong) [Z80]
+crzrallya (made by ShimaPong) [Z80]
+crzrallyg (made by ShimaPong) [Z80]
+csilver (made by ShimaPong) [M6809]
+csilverj (made by ShimaPong) [M6809]
+cstlevna (made by ShimaPong) [N2A03]
+csuperas (made by ShimaPong) [M6502]
+ct2k3sa (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ct2k3sp (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+cterrani (made by ShimaPong) [M6502]
+cthd2003 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ctisland (made by ShimaPong) [M6502]
+ctisland2 (made by ShimaPong) [M6502]
+ctomaday (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ctornado (made by ShimaPong) [M6502]
+ctrpllrp (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+cubeqst (made by Pugsy) [68000]
+cubeqsta (made by Pugsy) [68000]
+cuebrick (made by Pugsy) [68000]
+cuebrickj (made by Pugsy) [68000]
+cupfinal (made by Tourniquet(Region Code)) [68EC020]
+cyberlip (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+cybertnk (made by Pugsy) [68000]
+czeroize (made by ShimaPong) [M6502]
+dacholer (made by ShimaPong) [Z80]
+daikaiju (made by ShimaPong) [Z80]
+dairesya (made by Pugsy) [M6809]
+daisenpu (made by Pugsy) [68000]
+dangseed (made by ShimaPong) [M6809]
+dankuga (made by Tourniquet(Region Code)) [68EC020]
+daraku (made by Pugsy) [SH-2]
+dariusg (made by Tourniquet(Region Code)) [68EC020]
+dariusgj (made by Tourniquet(Region Code)) [68EC020]
+dariusgu (made by Tourniquet(Region Code)) [68EC020]
+dariusgx (made by Tourniquet(Region Code)) [68EC020]
+darkmist (made by ShimaPong) [Z80]
+darktowr (made by ShimaPong) [HD6309]
+darthvdr (made by Pugsy) [8080]
+darwin (made by ShimaPong) [M6809]
+ddayjlc (made by ShimaPong) [Z80]
+ddayjlca (made by ShimaPong) [Z80]
+ddungeon (made by ShimaPong) [M6809]
+ddungeone (made by ShimaPong) [M6809]
+defcmnd (made by Pugsy) [M6809]
+defence (made by Pugsy) [M6809]
+defender (made by Pugsy) [M6809]
+defenderb (made by Pugsy) [M6809]
+defenderg (made by Pugsy) [M6809]
+defenderw (made by Pugsy) [M6809]
+deltrace (made by Pugsy) [Z80]
+demndrgn (made by ShimaPong) [Z80]
+demon (made by Pugsy) [CCPU]
+demoneye (made by Pugsy) [M6502]
+desertwr (made by Pugsy) [V70]
+destryer (made by Pugsy) [CDP1802]
+destryera (made by Pugsy) [CDP1802]
+devilfsg (made by ShimaPong) [Z80]
+devilfsh (made by ShimaPong) [Z80]
+diehard (made by Pugsy) [SH-2]
+digdug (made by ShimaPong) [Z80]
+digdug1 (made by ShimaPong) [Z80]
+digdug2 (made by ShimaPong) [M6809]
+digdug2o (made by ShimaPong) [M6809]
+digdugat (made by ShimaPong) [Z80]
+digdugat1 (made by ShimaPong) [Z80]
+digger (made by ShimaPong) [Z80]
+diggerc (made by Shimapong) [S2650]
+diggerma (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+digsid (made by ShimaPong) [Z80]
+dino (originally made by ugetab/replaced with better ones by Shimapong) [68000]
+dinohunt (originally made by ugetab/replaced with better ones by Shimapong) [68000]
+dinoj (originally made by ugetab/replaced with better ones by Shimapong) [68000]
+dinopic {untested} (originally made by ugetab/replaced with better ones by Shimapong) [68000]
+dinopic2 ({untested} originally made by ugetab/replaced with better ones by Shimapong) [68000]
+dinou (originally made by ugetab/replaced with better ones by Shimapong) [68000]
+djboy (made by Pugsy) [Z80]
+djboya (made by Pugsy) [Z80]
+djboyj (made by Pugsy) [Z80]
+dkngjnrb (made by Pugsy {Invincibility} & PhantomDJ {Kill Screen Fix}) [Z80]
+dkong (made by aycaramba {Invincibility/level} & PhantomDJ {Kill Screen Fix}) [Z80]
+dkong3 (made by ShimaPong) [Z80]
+dkong3b (made by ShimaPong) [Z80]
+dkong3j (made by ShimaPong) [Z80]
+dkongj (made by aycaramba {Invincibility/level} & PhantomDJ {Kill Screen Fix}) [Z80]
+dkongjnrj (made by Pugsy {Invincibility} & PhantomDJ {Kill Screen Fix}) [Z80]
+dkongjo (made by aycaramba {Invincibility/level} & PhantomDJ {Kill Screen Fix}) [Z80]
+dkongjo1 (made by aycaramba {Invincibility/level} & PhantomDJ {Kill Screen Fix}) [Z80]
+dkongjr (made by Pugsy {Invincibility} & PhantomDJ {Kill Screen Fix}) [Z80]
+dkongjrb (made by Pugsy {Invincibility} & PhantomDJ {Kill Screen Fix}) [Z80]
+dkongjrj (made by Pugsy {Invincibility} & PhantomDJ {Kill Screen Fix}) [Z80]
+dkongjrm (made by Pugsy {Invincibility} & PhantomDJ {Kill Screen Fix}) [Z80]
+dkongo (made by aycaramba {Invincibility/level} & PhantomDJ {Kill Screen Fix}) [Z80]
+dnmtdeka (made by Pugsy) [SH-2]
+dockman (made by ShimaPong) [Z80]
+dokidoki (made by ShimaPong) [Z80]
+domino (made by ShimaPong) [Z80]
+dommy (made by Pugsy) [M6502]
+dorodon (made by ShimaPong) [Z80]
+dorodon2 (made by ShimaPong) [Z80]
+dorunrun (made by Pugsy) [Z80]
+dorunrun2 (made by Pugsy) [Z80]
+dorunrunc (made by Pugsy) [Z80]
+dorunrunca (made by Pugsy) [Z80]
+doubledr (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+dowild (made by ShimaPong) [Z80]
+draco (made by Pugsy) [CDP1802]
+drakton (made by Pugsy) [Z80]
+drgnbstr (made by ShimaPong) [M6809]
+drivfrcb (made by ShimaPong) [S2650]
+drivfrcg (made by ShimaPong) [S2650]
+drivfrcp (made by ShimaPong) [S2650]
+drktnjr (made by Pugsy) [Z80]
+drmicro (made by Pugsy) [Z80]
+drtoppel (made by Pugsy) [Z80]
+drtoppelj (made by Pugsy) [Z80]
+drtoppelu (made by Pugsy) [Z80]
+dungeonm (made by Tourniquet(Region Code)) [68EC020]
+dungeonmu (made by Tourniquet(Region Code)) [68EC020]
+dzigzag (made by ShimaPong) [Z80]
+eagle (updated/fixed by ShimaPong) [Z80]
+eagle2 (updated/fixed by ShimaPong) [Z80]
+eagle3 (made by ShimaPong) [Z80]
+eggor (made by ShimaPong) [Z80]
+eggs (made by Pugsy) [M6502]
+eightman (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+elim2 (made by Pugsy) [Z80]
+elim2a (made by Pugsy) [Z80]
+elim2c (made by Pugsy) [Z80]
+elim4 (made by Pugsy) [Z80]
+elim4p (made by Pugsy) [Z80]
+elvact2u (made by Tourniquet(Region Code)) [68EC020]
+elvact2u (made by VisitntX) [68EC020]
+elvactr (made by Tourniquet(Region Code)) [68EC020]
+elvactr (made by VisitntX) [68EC020]
+elvactrj (made by Tourniquet(Region Code)) [68EC020]
+elvactrj (made by VisitntX) [68EC020]
+enigma2 (made by ShimaPong) [Z80]
+enigma2a (made by ShimaPong) [Z80]
+enigma2b (made by ShimaPong) [Z80]
+eswat (made by Pugsy) [68000]
+eswatbl (made by Pugsy) [68000]
+eswatj (made by Pugsy) [68000]
+eswatu (made by Pugsy) [68000]
+evilston (made by ShimaPong) [Z80]
+excelsr (made by Shimapong) [68000]
+exerion (made by Mathias Schroeder) [Z80]
+exerionb (made by Mathias Schroeder) [Z80]
+exeriont (made by Mathias Schroeder) [Z80]
+exerizer (made by ShimaPong) [Z80]
+exerizerb (made by ShimaPong) [Z80]
+exodus (updated/fixed by ShimaPong) [Z80]
+explorer (made by Pugsy) [Z80]
+exprraid (made by ShimaPong) [M6502]
+exprraida (made by ShimaPong) [M6502]
+extrmatn (made by ShimaPong) [Z80]
+extrmatnj (made by ShimaPong) [Z80]
+extrmatnu (made by ShimaPong) [Z80]
+eyes (made by ShimaPong) [Z80]
+eyes2 (made by ShimaPong) [Z80]
+eyeszac (made by ShimaPong) [Z80]
+fa (made by Pugsy) [68000] {currently commented out}
+falcon (made by Pugsy) [I8085A]
+falconz (made by Pugsy) [Z80]
+fantasia (made by Pugsy) [68000]
+fantazia (updated/fixed by ShimaPong) [Z80]
+fantzn2 (made by Pugsy) [Z80]
+fantzone (made by ShimaPong) [68000]
+fantzone1 (made by ShimaPong) [68000]
+fantzonep (made by ShimaPong) [68000]
+farwest (made by Pugsy) [M6809]
+fastlane (made by ShimaPong) [HD6309]
+fatfursa (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+fatfursa (made by ShimaPong) [68000]
+fatfursp (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+fatfursp (made by ShimaPong) [68000]
+fatfury1 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+fatfury2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+fatfury2 (made by ShimaPong) [68000]
+fatfury3 (made by Pugsy & KelvSYC) [68000]
+fatfury3 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+fax (made by Pugsy) [M6502]
+faxa (made by Pugsy) [M6502]
+fbfrenzy (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+fcombat (made by ShimaPong) [Z80]
+ffantasy (made by ShimaPong) [68000]
+ffantasya (made by ShimaPong) [68000]
+ffantasybl (made by ShimaPong) [68000]
+fghtatck (made by Pugsy) [68000] {currently commented out}
+fgoal (made by ShimaPong) [M6800]
+fgoala (made by ShimaPong) [M6800]
+fightfev (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+fightfva (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+finalizr (made by ShimaPong) [M6809]
+finalizrb (made by ShimaPong) [M6809]
+firebatl (made by Pugsy) [Z80]
+flipshot (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+flkatck (made by ShimaPong) [HD6309]
+flower (made by ShimaPong) [Z80]
+flowerj (made by ShimaPong) [Z80]
+flytiger (made by Pugsy) [Z80] {Simple effective NOP of level reset}
+foodf (made by Pugsy) [68000]
+foodf2 (made by Pugsy) [68000]
+foodfc (made by Pugsy) [68000]
+forcebrk (made by ShimaPong) [M6809]
+formatz (made by ShimaPong) [M6809]
+frenzy (made by ShimaPong) [Z80]
+friskyt (made by ShimaPong) [Z80]
+friskyta (made by ShimaPong) [Z80]
+fshark (made by ShimaPong) [68000]
+fsharkbt (made by ShimaPong) [68000]
+fsoccerb (made by ShimaPong) [Z80]
+fspiderb (made by Pugsy) [Z80]
+fswords (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+funkybee (made by ShimaPong) [Z80]
+funkybeeb (made by ShimaPong) [Z80]
+fx (made by ShimaPong) [Z80]
+galaga (made by Pugsy (invincibility & starting level) & unknown mamedev (fast shoot) )
+galagamf (made by Pugsy (invincibility & starting level) & unknown mamedev (fast shoot) )
+galagamk (made by Pugsy (invincibility & starting level) & unknown mamedev (fast shoot) )
+galagamw (made by Pugsy (invincibility & starting level) & unknown mamedev (fast shoot) )
+galagao (made by Pugsy (invincibility & starting level) & unknown mamedev (fast shoot) )
+galap1 (made by Pugsy) [Z80]
+galap4 (made by Pugsy) [Z80]
+galapx (made by Pugsy) [Z80]
+galastrm (made by Pugsy) [68EC020]
+galaxbsf (made by Pugsy) [Z80]
+galaxia (made by Pugsy) [S2650]
+galaxian (made by Pugsy) [Z80]
+galaxiana (made by Pugsy) [Z80]
+galaxianm (made by Pugsy) [Z80]
+galaxianmo (made by Pugsy) [Z80]
+galaxiant (made by Pugsy) [Z80]
+galaxyfg (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+gallag (made by Pugsy (invincibility & starting level) & unknown mamedev (fast shoot) )
+gallop (made by Pugsy(objects)/improved by ShimaPong(scenery)) [V30]
+galsnew (made by Pugsy) [68000]
+galsnewa (made by Pugsy) [68000]
+galsnewj (made by Pugsy) [68000]
+galsnewk (made by Pugsy) [68000]
+galturbo (made by Pugsy) [Z80]
+ganryu (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+gardia (made by ShimaPong) [Z80]
+gardiab (made by ShimaPong) [Z80]
+garou (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+garou (made by Pugsy) [68000]
+garoubl (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+garoubl (made by Pugsy) [68000]
+garouo (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+garouo (made by Pugsy) [68000]
+garoup (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+garoup (made by Pugsy) [68000]
+gatsbee (made by Pugsy (invincibility & starting level) & unknown mamedev (fast shoot) )
+gauntlet (Walk through Walls made by Pugsy) [68010]
+gauntlet2p (Walk through Walls made by Pugsy) [68010]
+gauntlet2pg (Walk through Walls made by Pugsy) [68010]
+gauntlet2pg1 (Walk through Walls made by Pugsy) [68010]
+gauntlet2pj (Walk through Walls made by Pugsy) [68010]
+gauntlet2pj2 (Walk through Walls made by Pugsy) [68010]
+gauntlet2pr3 (Walk through Walls made by Pugsy) [68010]
+gauntletg (Walk through Walls made by Pugsy) [68010]
+gauntletj (Walk through Walls made by Pugsy) [68010]
+gauntletj12 (Walk through Walls made by Pugsy) [68010]
+gauntlets (Walk through Walls made by Pugsy) [68010]
+gberet (made by Pugsy) [Z80]
+gberetb (made by Pugsy) [Z80]
+gblchmp (made by ugetab) [68EC020]
+gekirido (made by Tourniquet(Region Code)) [68EC020]
+gekitsui (made by Pugsy) [M6809]
+genpeitd (made by ShimaPong) [M6809]
+getstar (made by ShimaPong) [Z80]
+getstarj (made by ShimaPong) [Z80]
+gforce2 (made by ShimaPong) [68000]
+gforce2j (made by ShimaPong) [68000]
+gforce2ja (made by ShimaPong) [68000]
+ghlpanic (made by Pugsy) [PSX CPU]
+ghostlop (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+gmgalax (Galaxian Invincibility made by Pugsy/Ghostmuncher speed hack made by ugetab) [Z80]
+gng (made by Pugsy & Bugfinder) [M6809]
+gnga (made by Pugsy & Bugfinder) [M6809]
+gngbl (made by Pugsy & Bugfinder) [M6809]
+gngblita (made by Pugsy & Bugfinder) [M6809]
+gngc (made by Pugsy & Bugfinder) [M6809]
+gngt (made by Pugsy & Bugfinder) [M6809]
+goalx3 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+goldbug (made by Pugsy) [S2650]
+goldnaxe (made by Pugsy) [68000]
+goldnaxe1 (made by Pugsy) [68000]
+goldnaxe2 (made by Pugsy) [68000]
+goldnaxe3 (made by Pugsy) [68000]
+goldnaxej (made by Pugsy) [68000]
+goldnaxeu (made by Pugsy) [68000]
+goonies (made by ShimaPong) [N2A03]
+gorf (made by Pugsy) [Z80]
+gorfpgm1 (made by Pugsy) [Z80]
+gorfpgm1g (made by Pugsy) [Z80]
+gotya (made by Pugsy) [Z80]
+gowcaizr (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+gpilots (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+gpilots (made by Pugsy) [68000]
+gpilotsh (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+gpilotsh (made by Pugsy) [68000]
+gprider1 (made by Pugsy) [68000]
+gradius2 (made by ShimaPong) [68000]
+gradius2a (made by ShimaPong) [68000]
+gradius2b (made by ShimaPong) [68000]
+gradius3 (made by ShimaPong) [68000]
+gradius3a (made by ShimaPong) [68000]
+gradius3e (made by ShimaPong) [68000]
+gradius4 (made by Pugsy) [PPC403]
+gravitar (made by Pugsy) [M6502]
+gravitar2 (made by Pugsy) [M6502]
+gravp (made by Pugsy) [M6502]
+grdforce (made by ShimaPong) [SH-2]
+griffon (made by Pugsy) [Z80]
+grobda (made by ShimaPong) [M6809]
+grobda2 (made by ShimaPong) [M6809]
+grobda3 (made by ShimaPong) [M6809]
+gseeker (made by Tourniquet(Region Code)) [68EC020]
+gseekerj (made by Tourniquet(Region Code)) [68EC020]
+gseekeru (made by Tourniquet(Region Code)) [68EC020]
+gsword (made by ShimaPong) [Z80]
+gsword2 (made by ShimaPong) [Z80]
+gteikob2 (updated/fixed by ShimaPong) [Z80]
+gteikokb (updated/fixed by ShimaPong) [Z80]
+gteikoku (updated/fixed by ShimaPong) [Z80]
+gtstarb1 (made by ShimaPong) [Z80]
+gtstarb2 (made by ShimaPong) [Z80]
+gulfwar2 (made by Jym/Pugsy) [68000]
+gunbustr (made by Tourniquet(Region Code)) [68EC020]
+gunlock (made by ShimaPong) [68EC020]
+gunsmoke (made by ShimaPong) [Z80]
+gunsmokej (made by ShimaPong) [Z80]
+gunsmokeu (made by ShimaPong) [Z80]
+gunsmokeua (made by ShimaPong) [Z80]
+gururin (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+gutangtn (made by ShimaPong) [Z80]
+guzzler (made by ShimaPong/added level select by Pugsy) [Z80]
+gyruss (made by Pugsy) [Z80]
+gyrussce (made by Pugsy) [Z80]
+halley87 (made by Pugsy) [M6809]
+halleycj (made by Pugsy) [M6809]
+halleys (made by Pugsy) [M6809]
+halleysc (made by Pugsy) [M6809]
+hangly (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+hangly2 (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+hangly3 (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+hangon (made by ShimaPong & Pugsy (acceleration)) [68000]
+hangon (made by ShimaPong) [68000]
+hangon1 (made by ShimaPong & Pugsy (acceleration)) [68000]
+hangon1 (made by ShimaPong) [68000]
+hangonjr (made by ShimaPong) [Z80]
+harddriv (made by Pugsy) [68010]
+harddriv1 (made by Pugsy) [68010]
+harddriv2 (made by Pugsy) [68010]
+harddriv3 (made by Pugsy) [68010]
+harddrivb (made by Pugsy) [68010]
+harddrivb5 (made by Pugsy) [68010]
+harddrivb6 (made by Pugsy) [68010]
+harddrivc (made by Pugsy) [68010]
+harddrivc1 (made by Pugsy) [68010]
+harddrivcb (made by Pugsy) [68010]
+harddrivcg (made by Pugsy) [68010]
+harddrivg (made by Pugsy) [68010]
+harddrivg4 (made by Pugsy) [68010]
+harddrivj (made by Pugsy) [68010]
+harddrivj6 (made by Pugsy) [68010]
+hardhead (made by Pugsy) [Z80]
+hardheadb (made by Pugsy) [Z80]
+headon (made by Pugsy) [Z80]
+headon2 (made by Pugsy) [Z80]
+headon2s (made by Pugsy) [Z80]
+headonb (made by Pugsy) [Z80]
+headoni (made by ShimaPong) [M6502]
+headons (made by Pugsy) [Z80]
+headonsa (made by Pugsy) [Z80]
+hellfire (made by ShimaPong) [68000]
+hellfire1 (made by ShimaPong) [68000]
+hellfire2 (made by ShimaPong) [68000]
+hellfire3 (made by ShimaPong) [68000]
+hero (made by Pugsy) [S2650]
+herodk (made by Pugsy) [S2650]
+herodku (made by Pugsy) [S2650]
+highsplt (made by ShimaPong) [8080]
+highsplta (made by ShimaPong) [8080]
+highspltb (made by ShimaPong) [8080]
+hippodrm (made by ShimaPong) [68000]
+hiryuken (made by ShimaPong) [Z80]
+hishouza (made by ShimaPong) [68000]
+holeland (made by ShimaPong) [Z80]
+hopmappy (made by Pugsy) [M6809]
+hotshock (made by Pugsy) [Z80]
+hotshockb (made by Pugsy) [Z80]
+hthero93 (made by Tourniquet(Region Code)) [68EC020]
+hthero94 (made by Tourniquet(Region Code)) [68EC020]
+hthero95 (made by Tourniquet(Region Code)) [68EC020]
+hthero95u (made by Tourniquet(Region Code)) [68EC020]
+hunchbak (made by Pugsy) [S2650]
+hunchbaka (made by Pugsy) [S2650]
+hunchbkd (made by Pugsy) [S2650]
+hunchbkg (made by Pugsy) [S2650]
+hunchbks (made by Pugsy) [S2650]
+hvoltage (made by Pugsy) [68000]
+iceclimb (made by Pugsy) [N2A03]
+iceclimbj (made by Pugsy) [N2A03]
+iceclmrj (made by Pugsy) [N2A03]
+iganinju (made by ShimaPong) [68000]
+igmo (made by Pugsy) [Z80]
+imago (made by Pugsy) [Z80]
+imagoa (made by Pugsy) [Z80]
+imgfight (made by Pugsy) [V30]
+imgfighto (made by Pugsy) [V30]
+imolagp (made by Pugsy) [Z80]
+imsorry (made by ShimaPong) [Z80]
+imsorryj (made by ShimaPong) [Z80]
+indianbt (made by ShimaPong) [8080]
+indytemp (made by Pugsy) [68010]
+indytemp2 (made by Pugsy) [68010]
+indytemp3 (made by Pugsy) [68010]
+indytemp4 (made by Pugsy) [68010]
+indytempd (made by Pugsy) [68010]
+intcup94 (made by Tourniquet(Region Code)) [68EC020]
+invaddlx (made by Pugsy) [8080]
+invader4 (made by Pugsy) [8080]
+invaderl (made by Pugsy) [8080]
+invaders (made by Pugsy) [8080]
+invadpt2 (made by Pugsy) [8080]
+invadrmr (made by Pugsy) [8080]
+invasion (made by Pugsy) [8080]
+invasiona (made by Pugsy) [8080]
+invasionb (made by Pugsy) [8080]
+invasionrz (made by Pugsy) [8080]
+invasionrza (made by Pugsy) [8080]
+ipminvad (made by Pugsy) [M6502]
+ironfort (made by Pugsy) [E1-32N]
+ironhors (made by Pugsy) [M6809]
+irrmaze (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+irrmaze (made by Pugsy) [68000]
+jackrabt (made by Pugsy) [Z80]
+jackrabt2 (made by Pugsy) [Z80]
+jackrabts (made by Pugsy) [Z80]
+jailbrek (made by ShimaPong) [M6809]
+jailbrekb (made by ShimaPong) [M6809]
+jajamaru (made by ShimaPong) [N2A03]
+janjans2 (made by ShimaPong) [V60]
+janptr96 (made by ShimaPong) [Z80]
+janshin (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+jedi (made by Pugsy) [M6502]
+jigkmgri (made by Pugsy) [68000]
+jin (made by Jym) [M6809] {Buggy}
+jituroku (made by ShimaPong) [Z80]
+jockeygp (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+joinem (made by ShimaPong) [Z80]
+jollyjgr (made by ShimaPong) [Z80]
+jongbou (made by ShimaPong) [68000]
+journey (made by ShimaPong) [Z80]
+joust (made by MRG) [M6809]
+joustr (made by MRG) [M6809]
+joustwr (made by MRG) [M6809]
+joyjoy (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+joyman (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+jpopnics (made by Pugsy) [Z80]
+jrking (made by Pugsy {Invincibility} & PhantomDJ {Kill Screen Fix}) [Z80]
+jrpacman (made by ShimaPong (Invincibility) & ugetab (Speed Hack)) [Z80]
+jrpacmbl (made by ShimaPong (Invincibility) & ugetab (Speed Hack)) [Z80]
+jspecter (made by Pugsy) [8080]
+jspecter2 (made by Pugsy) [8080]
+juju (made by Pugsy) [68000]
+jumpcoas (made by ShimaPong) [Z80]
+jumpcoast (made by ShimaPong) [Z80]
+junofrst (made by ShimaPong) [M6809]
+junofrstg (made by ShimaPong) [M6809]
+kabukikl (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kabukikl (made by ShimaPong) [68000]
+kabukiz (made by ShimaPong) [Z80]
+kabukizj (made by ShimaPong) [Z80]
+kageki (made by ShimaPong) [Z80]
+kagekih (made by ShimaPong) [Z80]
+kagekij (made by ShimaPong) [Z80]
+kaiserkn (made by ugetab) [68EC020]
+kaiserknj (made by ugetab) [68EC020]
+kaitei (made by ShimaPong) [8080]
+kaitein (made by ShimaPong) [8080]
+kamakazi3 (made by Pugsy) [Z80]
+kamikcab (made by Pugsy) [DECO CPU16]
+kangaroo (made by ShimaPong) [Z80]
+kangarooa (made by ShimaPong) [Z80]
+kangaroob (made by ShimaPong) [Z80]
+karnov (made by ShimaPong) [68000]
+karnovj (made by ShimaPong) [68000]
+karnovr (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kazan (made by ShimaPong) [68000]
+kbash (made by ShimaPong) [68000]
+kbash2 (made by ShimaPong) [68000]
+kf10thep (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kf2k2mp (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kf2k2mp2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kf2k2pla (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kf2k2pls (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kf2k3bl (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kf2k3bla (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kf2k3pcb (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kf2k3pl (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kf2k3upl (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kf2k5uni (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kickboy (made by ShimaPong) [Z80]
+kicker (made by Pugsy) [M6809]
+kicknrun (made by ShimaPong) [Z80]
+kikikai (made by ShimaPong) [Z80]
+killcom (made by ShimaPong) [M6502]
+kingball (made by ShimaPong) [Z80]
+kingballj (made by ShimaPong) [Z80]
+kingofb (made by ShimaPong) [Z80]
+kizuna (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+klondkp (made by RedBeam) [E1-16T]
+kngtmare (made by ShimaPong) [I8086]
+knightb (made by ShimaPong) [Z80]
+kodure (made by ShimaPong) [68000]
+kof10th (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof2000 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof2000n (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof2001 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof2001h (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof2002 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof2003 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof2k4se (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof94 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof94 (made by ShimaPong) [68000]
+kof95 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof95 (made by ShimaPong) [68000]
+kof95h (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof95h (made by ShimaPong) [68000]
+kof96 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof96 (made by Pugsy) [68000]
+kof96h (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof96h (made by Pugsy) [68000]
+kof97 (made by Bugfinder) [68000] ("No Damage Dealt While Defending")
+kof97 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof97h (made by Bugfinder) [68000] ("No Damage Dealt While Defending") {UNTESTED}
+kof97h (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof97pls (made by Bugfinder) [68000] ("No Damage Dealt While Defending") {UNTESTED}
+kof97pls (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof98 (made by Bugfinder) [68000] ("Enable Omega Rugal") {CHEAT MAY NEED TYPE CHANGING WHEN GAME WORKS}
+kof98 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof98h (made by Bugfinder) [68000] ("Enable Omega Rugal")
+kof98h (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof98k (made by Bugfinder) [68000] ("Enable Omega Rugal")
+kof98k (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof98ka (made by Bugfinder) [68000] ("Enable Omega Rugal")
+kof98ka (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof99 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof99a (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof99e (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof99k (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kof99p (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kog (made by Bugfinder) [68000] ("No Damage Dealt While Defending") {UNTESTED}
+kog (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kok (Game 1 Cookie) (made by Pugsy) [Z80]
+kok (Game 2 Jet Pac) (made by Pugsy) [Z80]
+kok (Game 3 Pssst) (made by Pugsy) [Z80]
+konam80a (ROM codes converted from various games by Pugsy) [VARIOUS]
+konam80j (ROM codes converted from various games by Pugsy) [VARIOUS]
+konam80k (ROM codes converted from various games by Pugsy) [VARIOUS]
+konam80s (ROM codes converted from various games by Pugsy) [VARIOUS]
+konam80u (ROM codes converted from various games by Pugsy) [VARIOUS]
+konamigt (made by ShimaPong) [68000]
+konek (made by Pugsy) [8080]
+korosuke (made by ShimaPong) [Z80]
+kosmokil (made by ShimaPong) [Z80]
+kotm (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kotm2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kotm2 (made by Pugsy) [68000]
+kotmh (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+kov (made by ShimaPong) [68000]
+kov115 (made by ShimaPong) [68000]
+kov2 (made by ShimaPong) [68000]
+kov2100 (made by ShimaPong) [68000]
+kov2102 (made by ShimaPong) [68000]
+kov2103 (made by ShimaPong) [68000]
+kov2106 (made by ShimaPong) [68000]
+kovj (made by ShimaPong) [68000]
+kram (made by ShimaPong) [M6809]
+kram2 (made by ShimaPong) [M6809]
+kram3 (made by ShimaPong) [M6809]
+krull (made by ShimaPong) [I8086]
+ktiger (made by Jym/Pugsy) [68000]
+ktiger2 (made by Tourniquet(Region Code)) [68EC020]
+kungfut (made by ShimaPong) [Z80]
+kungfuta (made by ShimaPong) [Z80]
+kuniokun (made by ShimaPong) [M6502]
+kuniokunb (made by ShimaPong) [M6502]
+kurikina (made by ShimaPong) [Z80]
+kurikinj (made by ShimaPong) [Z80]
+kurikint (made by ShimaPong) [Z80]
+kurikinu (made by ShimaPong) [Z80]
+ladybgb2 (made by ShimaPong) [Z80]
+ladybug (made by ShimaPong) [Z80]
+ladybugb (made by ShimaPong) [Z80]
+ladybugg (made by ShimaPong) [Z80]
+ladyfrog (made by ShimaPong) [Z80]
+landmakr (made by Tourniquet(Region Code)) [68EC020]
+lans2004 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+laserbat (made by ShimaPong) [S2650]
+lasso (made by ShimaPong) [M6502]
+lastblad (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+lastbladh (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+lastbld2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+lastday (made by Pugsy) [Z80]
+lastdaya (made by Pugsy) [Z80]
+lastmisn (made by ?) [???]
+lastmisnj (made by ?) [???]
+lastmisno (made by ?) [???]
+lastsold (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+lazarian (made by ShimaPong) [S2650]
+lbowling (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+le2 (made by ShimaPong) [68EC020]
+le2j (made by ShimaPong) [68EC020]
+le2u (made by ShimaPong) [68EC020]
+legend (made by ShimaPong) [Z80]
+legendos (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+legion (made by Pugsy) [68000]
+legiono (made by Pugsy) [68000]
+leprechn (made by ShimaPong) [M6502]
+leprechp (made by ShimaPong) [M6502]
+lightbr (made by Tourniquet(Region Code)) [68EC020]
+lightbrj (made by Tourniquet(Region Code)) [68EC020]
+lizwiz (made by ShimaPong) [Z80]
+lockon (made by Pugsy) [V30]
+lockonc (made by Pugsy) [V30]
+locomotn (made by ShimaPong) [Z80]
+lordgun (made by ShimaPong) [68000]
+loverboy (made by Pugsy) [Z80]
+lresort (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+lsrquiz (made by Pugsy) [68EC020]
+lsrquiz2 (made by Pugsy) [68EC020]
+lunarba1 (made by Pugsy) [M6502]
+lunarbat (made by Pugsy) [M6502]
+mach3 (made by Pugsy) [I8086]
+madalien (made by Pugsy/fixed & other ROM cheats added by ShimaPong) [M6502]
+madaliena (made by Pugsy/fixed & other ROM cheats added by ShimaPong) [M6502]
+madball (made by ShimaPong) [Z80]
+madballn (made by ShimaPong) [Z80]
+maddonna (made by Kriptokapi/with some fixing (Part 2) by Pugsy) [68000]
+magdrop2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+magdrop3 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+maglord (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+maglordh (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+magmax (made by ShimaPong) [68000]
+magworm (made by Pugsy) [M6502]
+mahretsu (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+makaimur (made by Pugsy & Bugfinder) [M6809]
+makaimurc (made by Pugsy & Bugfinder) [M6809]
+makaimurg (made by Pugsy & Bugfinder) [M6809]
+maketrax (made by ShimaPong) [Z80]
+maketrxb (made by ShimaPong) [Z80]
+malzak (made by ShimaPong) [S2650]
+malzak2 (made by ShimaPong) [S2650]
+manhatan (made by ShimaPong) [M6809]
+marble (made by Pugsy) [68010]
+marble2 (made by Pugsy) [68010]
+marble3 (made by Pugsy) [68010]
+marble4 (made by Pugsy) [68010]
+marble5 (made by Pugsy) [68010]
+marineb (updated/fixed by ShimaPong) [Z80]
+mariner (made by Pugsy) [Z80]
+mario (made by Pugsy) [Z80]
+marioe (made by Pugsy) [Z80]
+marioj (made by Pugsy) [Z80]
+marioo (made by Pugsy) [Z80]
+markham (updated/fixed by ShimaPong) [Z80]
+martmast (made by ShimaPong) [68000]
+martmastc (made by ShimaPong) [68000]
+martmastc102 (made by ShimaPong) [68000]
+marukodq (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+marvins (made by ShimaPong) [Z80]
+marvland (made by Pugsy) [68000]
+marvlandj (made by Pugsy) [68000]
+masao (made by Pugsy) [Z80]
+masterw (made by ShimaPong) [???]
+masterwj (made by ShimaPong) [???]
+masterwu (made by ShimaPong) [???]
+matrim (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+mayday (made by Pugsy) [M6809]
+maydaya (made by Pugsy) [M6809]
+maydayb (made by Pugsy) [M6809]
+mazeinv (made by Pugsy) [M6502]
+mbrush (made by ShimaPong) [Z80]
+mcombat (made by Pugsy) [M6502]
+mcombata (made by Pugsy) [M6502]
+megaforc (made by ShimaPong) [Z80]
+megatack (made by Pugsy) [M6502]
+megazone (made by ShimaPong) [M6809]
+megazonea (made by ShimaPong) [M6809]
+megazoneb (made by ShimaPong) [M6809]
+megazonec (made by ShimaPong) [M6809]
+megazonei (made by ShimaPong) [M6809]
+merlinmm (made by Pugsy) [Z80]
+mermaid (made by ShimaPong) [Z80]
+metamrph (made by ShimaPong) [68000]
+metamrphj (made by ShimaPong) [68000]
+metamrphu (made by ShimaPong) [68000]
+meteorho (made by Pugsy) [M6502]
+meteorts (made by Pugsy) [M6502]
+metlhawk (made by ShimaPong) [68000]
+metlhawkj (made by ShimaPong) [68000]
+metlsavr (made by ShimaPong) [68000]
+metmqstr (made by ShimaPong) [68000]
+metrocrs (made by ShimaPong) [M6809]
+metrocrsa (made by ShimaPong) [M6809]
+mexico86 (made by ShimaPong) [Z80]
+mf_achas (made by Pugsy) [M6502]
+mf_bdash (made by ShimaPong) [M6502]
+miexchng (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+mightguy (made by ShimaPong) [Z80]
+mikie (made by ShimaPong) [M6809]
+mikiehs (made by ShimaPong) [M6809]
+mikiej (made by ShimaPong) [M6809]
+milliped (made by Pugsy) [M6502]
+millpac (made by Pugsy) [M6502]
+minasan (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+mirax (made by Pugsy) [Z80]   
+miraxa (made by Pugsy) [Z80]  
+missile (made by Pugsy) [M6502]
+missile2 (made by Pugsy) [M6502]
+mjgtaste (made by ShimaPong) [SH-2]
+mjneogeo (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+mk (made by Steph & ugetab, Clues and Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mk2 (updated by ugetab, Clues and Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mk2chal (updated by ugetab, Clues and Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mk2r14 (updated by ugetab) [TMS34010]
+mk2r21 (updated by ugetab, Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mk2r30 (updated by ugetab, Clues and Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mk2r31e (updated by ugetab, Clues and Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mk2r32 (updated by ugetab, Clues and Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mk2r42 (updated by ugetab, Clues and Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mk2r91 (updated by ugetab, Clues and Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mk3 (made by Steph & ugetab) [TMS34010]
+mk3r10 (made by Steph & ugetab) [TMS34010]
+mk3r20 (made by Steph & ugetab) [TMS34010]
+mkla1 (made by Steph & ugetab, Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mkla2 (made by Steph & ugetab, Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mkla3 (made by Steph & ugetab, Clues and Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mkla4 (made by Steph & ugetab, Clues and Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mkprot9 (made by Steph & ugetab, Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mkr4 (made by Steph , Clues and Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mktturbo (made by Steph & ugetab, Clues and Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mkyawdim (made by Steph & ugetab, Clues and Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mkyturbo (made by Steph & ugetab, Clues and Secret Game Over & CPU Fatality by Pugsy) [TMS34010]
+mmatrix (made by Pugsy) [68000] {COMMENTED OUT}
+mmatrixd (made by Pugsy) [68000] {COMMENTED OUT}
+mmatrixj (made by Pugsy) [68000] {COMMENTED OUT}
+moguchan (made by ShimaPong) [Z80]
+mole (made by ShimaPong) [M6502]
+momoko (made by ShimaPong) [Z80]
+monkeyd (made by aycaramba {Invincibility/level} & PhantomDJ {Kill Screen Fix}) [Z80]
+monsterb (made by ShimaPong) [Z80]
+monsterb2 (made by ShimaPong) [Z80] {NOT WORK ON 0.101u1 OR LATER}
+moonal2 (made by Pugsy) [Z80]
+moonal2b (made by Pugsy) [Z80]
+moonaln (made by Pugsy) [Z80]
+moonbase (made by Pugsy) [8080]
+moonbasea (made by Pugsy) [8080]
+mooncmw (updated/fixed by ShimaPong) [Z80]
+mooncrgx (updated/fixed by ShimaPong) [Z80]
+mooncrs2 (updated/fixed by ShimaPong) [Z80]
+mooncrs3 (updated/fixed by ShimaPong) [Z80]
+mooncrsb (updated/fixed by ShimaPong) [Z80]
+mooncrst (updated/fixed by ShimaPong) [Z80]
+mooncrstg (updated/fixed by ShimaPong) [Z80]
+mooncrsto (updated/fixed by ShimaPong) [Z80]
+mooncrstu (updated/fixed by ShimaPong) [Z80]
+mooncrstuk (updated/fixed by ShimaPong) [Z80]
+moonwar (made by Pugsy) [Z80]
+moonwara (made by Pugsy) [Z80]
+moonwarp (made by Pugsy) [Z80]
+mosyougi (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+motos (made by ShimaPong) [M6809]
+mouser (made by Pugsy) [Z80]
+mouserc (made by Pugsy) [Z80]
+mp_gaxe2 (made by ShimaPong) [68000]
+mp_soni2 (made by ShimaPong) [68000]
+mp_sor2 (made by ShimaPong) [68000]
+mrdo (made by Pugsy) [Z80]
+mrdofix (made by Pugsy) [Z80]
+mrdot (made by Pugsy) [Z80]
+mrdoy (made by Pugsy) [Z80]
+mrdu (made by Pugsy) [Z80]
+mrflea (made by Pugsy) [Z80]
+mrgoemon (made by ShimaPong) [Z80]
+mrheli (made by ShimaPong) [V30]
+mrjong (made by ShimaPong) [Z80]
+mrkougar (made by ShimaPong) [Z80]
+mrkougar2 (made by ShimaPong) [Z80]
+mrkougb (made by ShimaPong) [Z80]
+mrkougb2 (made by ShimaPong) [Z80]
+mrlo (made by Pugsy) [Z80]
+mrviking (made by ShimaPong) [Z80]
+mrvikingj (made by ShimaPong) [Z80]
+ms4plus (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ms5pcb (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ms5plus (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+mschamp (made by ShimaPong (Invincibility) & ugetab (Speed Hack)) [Z80]
+mschamps (made by ShimaPong (Invincibility) & ugetab (Speed Hack)) [Z80]
+mshuttle (made by Pugsy) [Z80]
+mshuttlej (made by Pugsy) [Z80]
+mshuttlej2 (made by Pugsy) [Z80]
+mslug (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+mslug2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+mslug3 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+mslug3b6 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+mslug3h (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+mslug4 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+mslug4h (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]  
+mslug5 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+mslug5h (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+mslugx (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+mspacmab (made by ShimaPong (Invincibility) & ugetab (Speed Hack)) [Z80]
+mspacman (made by ShimaPong (Invincibility) & ugetab (Speed Hack)) [Z80]
+mspacmat (made by ShimaPong (Invincibility) & ugetab (Speed Hack)) [Z80]
+mspacmbe (made by ShimaPong (Invincibility) & ugetab (Speed Hack)) [Z80]
+mspacmnf (made by ShimaPong (Invincibility) & ugetab (Speed Hack)) [Z80]
+mspacpls (made by ShimaPong (Invincibility) & ugetab (Speed Hack)) [Z80]
+mtrap (made by Pugsy) [M6502]
+mtrap3 (made by Pugsy) [M6502]
+mtrap4 (made by Pugsy) [M6502]
+mt_arrow (made by Pugsy) [68000]
+mt_astro (made by Pugsy) [Z80]
+mt_beast (made by ShimaPong) [68000]
+mt_fshrk (made by Pugsy) [68000]
+mt_gaxe2 (made by ShimaPong) [68000]
+mt_gng (made by Pugsy) [68000]
+mt_lastb (made by ShimaPong) [68000]
+mt_mwalk (made by Pugsy) [68000]
+mt_shado (made by Pugsy) [68000]
+mt_shar2 (made by ShimaPong) [68000]
+mt_soni2 (made by ShimaPong) [68000]
+mt_spman (made by Pugsy) [68000]
+mt_stbld (made by ShimaPong) [68000]
+mugsmash (made by ShimaPong) [68000]
+multigam {10. Ice Climber} (made by Pugsy) [N2A03]
+multigam {12. Road Fighter} (made by Pugsy) [N2A03]
+multigam {15. Super Mario} (made by Pugsy) [N2A03]
+multigam {16. Twin Bee} (based on NES codes by Whipon) [N2A03]
+multigam {18. New Type} (made by Pugsy) [N2A03]
+multigam {20. Son Son} (made by Pugsy) [N2A03]
+multigam {21. Galaga} (made by Pugsy) [N2A03]
+multigam {22. F1 Race} (made by Pugsy) [N2A03]
+multigam {24. Bomb Jack (Mighty Bombjack)} (made by Pugsy) [N2A03]
+multigam {25. Ninja} (made by Pugsy) [N2A03]
+multigam {26. Gorilla 3} (made by Pugsy) [N2A03]
+multigam {28. Mr Mario (Mario Bros)} (made by Pugsy) [N2A03]
+multigam {3. Star Force} (made by Pugsy) [N2A03]
+multigam {33. Arabian} (made by Pugsy) [N2A03]
+multigam {4. Sky Destroyer} (made by Pugsy) [N2A03]
+multigam {7.  Pac Man} (based on NES code by megaman_exe) [N2A03]
+multigam {9. Circus Charlie} (made by Pugsy) [N2A03]
+multigm2 {11. Popeye} (made by Pugsy) [N2A03]
+multigm2 {12. Road Fighter} (made by Pugsy) [N2A03]
+multigm2 {15. Pooyan} (made by Pugsy) [N2A03]
+multigm2 {20. Ninja 3} (made by Pugsy) [N2A03]
+multigm2 {21. Exerion} (made by Pugsy) [N2A03]
+multigm2 {3. Mr Mario (Mario Bros)} (made by Pugsy) [N2A03]
+multigm2 {4. Islander (Wonder Boy)} (made by Pugsy) [N2A03]
+multigm2 {5. Circus (Circus Charlie)} (made by Pugsy) [N2A03]
+multigm2 {9. Mario 1 (Super Mario Bros)} (made by Pugsy) [N2A03]
+multigm3 {10. Galaga} (made by Pugsy) [N2A03]
+multigm3 {11. Star Force} (made by Pugsy) [N2A03]
+multigm3 {12. King Kong (Donkey Kong Jr.)} (made by Pugsy) [N2A03]
+multigm3 {13. Pooyan} (made by Pugsy) [N2A03]
+multigm3 {14. Wonder Boy (made by Pugsy) [N2A03]
+multigm3 {16. Popeye} (made by Pugsy) [N2A03]
+multigm3 {17. Circus Troupe (Circus Charlie)} (made by Pugsy) [N2A03]
+multigm3 {18. Exerion} (made by Pugsy) [N2A03]
+multigm3 {19. Mappy} (made by Pugsy) [N2A03]
+multigm3 {2.  Super Mario} (made by Pugsy) [N2A03]
+multigm3 {20. Sky Destroyer} (made by Pugsy) [N2A03]
+multigm3 {21. Gorilla 3} (made by Pugsy) [N2A03]
+multigm3 {6.  Ice Climber} (made by Pugsy) [N2A03]
+multigm3 {7.  Road Fighter} (made by Pugsy) [N2A03]
+multigm3 {8.  Pac Man} (based on NES code by megaman_exe) [N2A03]
+multigm3 {9.  Bomber Man} (made by Pugsy) [N2A03]
+multigmb {10. Ice Climber} (made by Pugsy) [N2A03]
+multigmb {12. Road Fighter} (made by Pugsy) [N2A03]
+multigmb {15. Super Mario} (made by Pugsy) [N2A03]
+multigmb {16. Twin Bee} (based on NES codes by Whipon) [N2A03]
+multigmb {18. New Type} (made by Pugsy) [N2A03]
+multigmb {20. Son Son} (made by Pugsy) [N2A03]
+multigmb {21. Galaga} (made by Pugsy) [N2A03]
+multigmb {22. F1 Race} (made by Pugsy) [N2A03]
+multigmb {24. Bomb Jack (Mighty Bombjack)} (made by Pugsy) [N2A03]
+multigmb {25. Ninja} (made by Pugsy) [N2A03]
+multigmb {26. Gorilla 3} (made by Pugsy) [N2A03]
+multigmb {28. Mr Mario (Mario Bros)} (made by Pugsy) [N2A03]
+multigmb {3. Star Force} (made by Pugsy) [N2A03]
+multigmb {33. Arabian} (made by Pugsy) [N2A03]
+multigmb {4. Sky Destroyer} (made by Pugsy) [N2A03]
+multigmb {7.  Pac Man} (based on NES code by megaman_exe) [N2A03]
+multigmb {9. Circus Charlie} (made by Pugsy) [N2A03]
+multigmt {1.  Pac Man} (based on NES code by megaman_exe) [N2A03]
+multigmt {10. Mighty Bomb Jack} (made by Pugsy) [N2A03]
+multigmt {2. Super Mario} (made by Pugsy) [N2A03]
+multigmt {4. Road Fighter} (made by Pugsy) [N2A03]
+multigmt {5. Gorilla 3} (made by Pugsy) [N2A03]
+multigmt {8. Galaga} (made by Pugsy) [N2A03]
+mutnat (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+mx5000 (made by ShimaPong) [HD6309]
+myqbert (made by Pugsy) [8088]
+mystston (made by Pugsy) [M6502]
+myststono (made by Pugsy) [M6502]
+nam1975 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+navarone (made by ShimaPong) [8080]
+ncombat (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ncombath (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ncommand (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ncv1 (made by Pugsy (lives) & many more by ShimaPong (invincibility & others)) [68000]
+ncv1j (made by Pugsy (lives) & many more by ShimaPong (invincibility & others)) [68000]
+ncv1j2 (made by Pugsy (lives) & many more by ShimaPong (invincibility & others)) [68000]
+ncv2 (made by Pugsy (obsolete fix & lives) & many more by ShimaPong (invincibility & others)) [68000]
+ncv2j (made by Pugsy (obsolete fix & lives) & many more by ShimaPong (invincibility & others)) [68000]
+neobombe (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+neocup98 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+neodrift (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+neomrdo (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+netwars (made by ShimaPong) [Z80]
+newpuc2 (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+newpuc2b (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+newpuckx (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+nextfase (made by Pugsy) [8085A]
+nightlov (made by ShimaPong) [Z80]
+ninja (made by ShimaPong) [Z80]
+ninjakun (made by ShimaPong) [Z80]
+ninjamas (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ninjaw (made by ShimaPong) [68000]
+ninjawj (made by ShimaPong) [68000]
+nitd (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+nitdbl (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+nitedrvr (made by ShimaPong) [M6502]
+nmaster (made by ShimaPong) [68000]
+nmouse (made by ShimaPong) [Z80]
+nmouseb (made by ShimaPong) [Z80]
+nost (made by ShimaPong) [68000]
+nostj (made by ShimaPong) [68000]
+nostk (made by ShimaPong) [68000]
+nprinces (made by ShimaPong) [Z80]
+nprincesb (made by ShimaPong) [Z80]
+nprinceso (made by ShimaPong) [Z80]
+nprincesu (made by ShimaPong) [Z80]
+nrallyx (made by ShimaPong) [Z80]
+nratechu (made by Pugsy) [Z80]
+nss_actr (made by ShimaPong) [G65C816]
+nss_fzer (made by ShimaPong) [G65C816]
+nsub (made by Pugsy) [Z80]
+nunchaku (made by ShimaPong) [Z80]
+nyny (made by Pugsy) [M6809]
+nynyg (made by Pugsy) [M6809]
+ojousan (made by ShimaPong) [Z80]
+olibochu (made by Pugsy) [Z80]
+omegrace (made by Pugsy) [Z80]
+omni (made by ShimaPong) [Z80]
+opaopa (made by Pugsy) [Z80]
+osman (made by Pugsy) [ARM]
+outline (made by Pugsy) [S2650]
+overtop (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ozmawars (made by ShimaPong) [8080]
+ozmawars2 (made by ShimaPong) [8080]
+pacgal (made by ShimaPong (Invincibility) & ugetab (Speed Hack)) [Z80]
+pacheart (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+pacman (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+pacmanbl (made by ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+pacmanbla (made by ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+pacmanf (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+pacmania (made by RedBeam) [M6809]
+pacmaniaj (made by RedBeam) [M6809]
+pacmod (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+pacnchmp (made by Pugsy) [M6809]
+pacnpal (made by Pugsy) [M6809]
+pacnpal2 (made by Pugsy) [M6809]
+pacplus (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+paintlad (made by ShimaPong) [68000]
+paintrlr (made by ShimaPong) [Z80]
+pandoras (made by Pugsy) [M6809]
+panicbom (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+panther (made by Pugsy) [M6502]
+paperboy (made by Pugsy) [T11]
+paperboyr1 (made by Pugsy) [T11]
+paperboyr2 (made by Pugsy) [T11]
+paradise (made by ShimaPong) [Z80]
+paradlx (made by ShimaPong) [Z80]
+paranoia (made by Pugsy) [HuC6280]
+parodius (made by Pugsy) [KONAMI]
+parodiusj (made by Pugsy) [KONAMI]
+pballoon (made by ShimaPong) [M6502]
+pbobbl2n (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+pbobble2 (made by Tourniquet(Region Code)) [68EC020]
+pbobble2j (made by Tourniquet(Region Code)) [68EC020]
+pbobble2u (made by Tourniquet(Region Code)) [68EC020]
+pbobble2x (made by Tourniquet(Region Code)) [68EC020]
+pbobble3 (made by Tourniquet(Region Code)) [68EC020]
+pbobble3j (made by Tourniquet(Region Code)) [68EC020]
+pbobble3u (made by Tourniquet(Region Code)) [68EC020]
+pbobble4 (made by Tourniquet(Region Code)) [68EC020]
+pbobble4j (made by Tourniquet(Region Code)) [68EC020]
+pbobble4u (made by Tourniquet(Region Code)) [68EC020]
+pbobblen (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+pbobblenb (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+pc_1942 (made by ShimaPong) [N2A03]
+pc_cntra (made by jym) [N2A03]
+pc_cshwk (made by jym) [N2A03]
+pc_cvnia (made by jym) [N2A03]
+pc_ddrgn (made by ShimaPong) [N2A03]
+pc_duckh (made by jym) [N2A03]
+pc_ebike (made by Pugsy) [N2A03]
+pc_grdue (made by ShimaPong) [N2A03]
+pc_grdus (made by ShimaPong) [N2A03]
+pc_mario (made by Pugsy) [N2A03]
+pc_miket (made by ugetab\Parasyte) [N2A03]
+pc_mman3 (made by ugetab)[N2A03] <-- These are converted Game Genie codes from the NES 6502 version, RAM cheats would be easy though GG uses ROM codes!
+pc_mtoid (made by Pugsy) [N2A03]
+pc_ngai2 (made by ugetab) [N2A03]
+pc_ngai3 (made by ugetab) [N2A03]
+pc_ngaid (made by ShimaPong) [N2A03]
+pc_radr2 (made by ShimaPong) [N2A03]
+pc_radrc (made by ShimaPong) [N2A03]
+pc_rkats (made by ugetab) [N2A03] <-- These are converted Game Genie codes from the NES 6502 version, RAM cheats would be easy though GG uses ROM codes!
+pc_rygar (made by ShimaPong) [N2A03]
+pc_smb (made by ugetab) [N2A03]
+pc_smb2 (made by ugetab) [N2A03]
+pc_smb3 (made by ugetab) [N2A03]
+pc_suprc (made by jym) [N2A03]
+pc_tmnt (made by ugetab) [N2A03]
+pc_ynoid (made by Pugsy) [N2A03] <-- These are converted Game Genie codes from the NES 6502 version, RAM cheats would be easy though GG uses ROM codes!
+pengo (made by ShimaPong) [Z80]
+pengo2 (made by ShimaPong) [Z80]
+pengo2u (made by ShimaPong) [Z80]
+pengo3u (made by ShimaPong) [Z80]
+pengo4 (made by ShimaPong) [Z80]
+pengob (made by ShimaPong) [Z80]
+penta (made by ShimaPong) [Z80]
+perestro (made by Pugsy) [Z80]
+perestrof (made by Pugsy) [Z80]
+perfrman (made by Pugsy) [Z80]
+perfrmanu (made by Pugsy) [Z80]
+pestplce (made by Pugsy) [Z80]
+peterpak (made by Pugsy) [68010]
+pgoal (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+phantom (made by Pugsy) [M6502]
+phantoma (made by Pugsy) [M6502]
+phelios (made by Pugsy) [68000]
+phoenix (made by Pugsy) [8085A]
+phoenix3 (made by Pugsy) [8085A]
+phoenixa (made by Pugsy) [8085A]
+phoenixb (made by Pugsy) [8085A]
+phoenixc (made by Pugsy) [8085A]
+phoenixt (made by Pugsy) [8085A]
+phoenxp2 (made by Pugsy) [Z80]
+phozon (made by ShimaPong) [M6809]
+phpython (made by Pugsy) [8080]
+pickin (made by ShimaPong) [Z80]
+pignewt (made by ShimaPong) [Z80]
+pignewta (made by ShimaPong) [Z80]
+piranha (made by ShimaPong (Invincibility) & ugetab (Speed Hack)) & PhantomDJ (Split Screen Fix) ) [Z80]
+piranhah (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+piranhao (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+piratetr (made by ShimaPong) [M6502]
+pisces (made by ShimaPong) [Z80]
+piscesb (made by ShimaPong) [Z80]
+pitfall2 (made by Pugsy) [Z80]
+pitfalla (made by Pugsy) [Z80]
+pitfallu (made by Pugsy) [Z80]
+pkunwar (made by ShimaPong) [Z80]
+pkunwarj (made by ShimaPong) [Z80]
+plegends (made by ShimaPong) [68000]
+plegendsj (made by ShimaPong) [68000]
+pleiadbl (made by Pugsy) [8085A]
+pleiadce (made by Pugsy) [8085A]
+pleiads (made by Pugsy) [8085A]
+plumppop (made by Pugsy) [Z80]
+plusalph (made by ShimaPong) [68000]
+pnyaa (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+polaris (made by Pugsy) [Z80]
+polarisa (made by Pugsy) [Z80]
+polariso (made by Pugsy) [Z80]
+ponpoko (made by ShimaPong) [Z80]
+ponpokov (made by ShimaPong) [Z80]
+popbounc (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+popeyeman (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+popflame (made by ShimaPong) [Z80]
+popflamea (made by ShimaPong) [Z80]
+popflameb (made by ShimaPong) [Z80]
+popflamen (made by ShimaPong) [Z80]
+popnpop (made by Tourniquet(Region Code)) [68EC020]
+popnpopj (made by Tourniquet(Region Code)) [68EC020]
+popnpopu (made by Tourniquet(Region Code)) [68EC020]
+popper (made by ShimaPong) [Z80]
+pop_hh (made by Pugsy) [Z80]
+porter (made by ShimaPong) [Z80]
+portman (made by ShimaPong) [Z80]
+potogold (made by ShimaPong) [M6502]
+powerbal (made by ShimaPong) [68000]
+powerbals (made by ShimaPong) [68000]
+preisle2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+prmtmfgt (made by Tourniquet(Region Code)) [68EC020]
+prmtmfgto (made by Tourniquet(Region Code)) [68EC020]
+pspikes2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+pturn (made by ShimaPong) [Z80]
+puchicar (made by Tourniquet(Region Code)) [68EC020]
+puchicarj (made by Tourniquet(Region Code)) [68EC020]
+puckman (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+puckmana (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+puckmanf (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+puckmanh (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+puckmod (made by ShimaPong (Invincibility) & ugetab (Speed Hack) & PhantomDJ (Split Screen Fix) ) [Z80]
+pulstar (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+pulstar (made by Pugsy) [68000]
+punipic {untested} (made by RedBeam) [68000]
+punipic2 {untested} (made by RedBeam) [68000]
+punipic3 {untested} (made by RedBeam) [68000]
+punisher (made by RedBeam) [68000]
+punisherbz (made by RedBeam) [68000]
+punisherj (made by RedBeam) [68000]
+punisheru (made by RedBeam) [68000]
+puzzldpr (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+puzzledp (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+pwrgoal (made by Tourniquet(Region Code)) [68EC020]
+qb3 (made by Pugsy) [CCPU]
+qix (made by Pugsy) [M6809]
+qix2 (made by Pugsy) [M6809]
+qixa (made by Pugsy) [M6809]
+qixb (made by Pugsy) [M6809]
+qixo (made by Pugsy) [M6809]
+quantum (made by Pugsy) [68000]
+quantum1 (made by Pugsy) [68000]
+quantump (made by Pugsy) [68000]
+quasar (made by Pugsy) [S2650]
+quasara (made by Pugsy) [S2650]
+quizdai2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+quizdais (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+quizdaisk (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+quizkof (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+quizkofk (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+r2dtank (made by ShimaPong) [M6809]
+radarscp (made by ShimaPong) [Z80]
+radarscp1 (made by ShimaPong) [Z80]
+radarzon (made by Pugsy) [S2650]
+radarzon1 (made by Pugsy) [S2650]
+radarzont (made by Pugsy) [S2650]
+radrad (made by ShimaPong) [Z80]
+raflesia (made by ShimaPong) [Z80]
+ragnagrd (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ragnagrd (updated/fixed by ShimaPong) [68000]
+raiders (made by ShimaPong) [S2650]
+raiders5 (made by Pugsy) [Z80]
+raiders5t (made by Pugsy) [Z80]
+rallys (made by Pugsy) [M6502]
+rallyx (made by ShimaPong) [Z80]
+rallyxa (made by ShimaPong) [Z80]
+rallyxm (made by ShimaPong) [Z80]
+rastan (made by Neil Pierce) [68000]
+rastanu (made by Neil Pierce) [68000]
+rastanu2 (made by Neil Pierce) [68000]
+rastsaga (made by Neil Pierce) [68000]
+rastsaga1 (made by Neil Pierce) [68000]
+raycris (made by Pugsy) [PSX CPU]
+rayforce (made by ShimaPong) [68EC020]
+rayforcej (made by ShimaPong) [68EC020]
+rbff1 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+rbff1a (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+rbff2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+rbff2h (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+rbff2k (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+rbffspec (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+rbffspeck (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+rbtapper (made by Pugsy) [Z80]
+redalert (made by ShimaPong) [M6502]
+redbaron (made by Pugsy) [M6502]
+redclash (updated/fixed by ShimaPong) [Z80]
+redclasha (made by ShimaPong) [Z80]
+redclashk (updated/fixed by ShimaPong) [Z80]
+redrobin (made by Pugsy) [Z80]
+redufo (updated/fixed by ShimaPong) [Z80]
+redufob (updated/fixed by ShimaPong) [Z80]
+regulus (made by ShimaPong) [Z80]
+reguluso (made by ShimaPong) [Z80]
+regulusu (made by ShimaPong) [Z80]
+renegade (made by ShimaPong) [M6502]
+renju (made by ShimaPong) [Z80]
+repulse (made by Shimapong) [Z80]
+rescue (made by Pugsy & Jym) [Z80]
+rezon (made by ShimaPong) [68000]
+rezont (made by ShimaPong) [68000]
+rf2 (made by ShimaPong) [68000]
+ribbit (made by ShimaPong) [68000]
+ridhero (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ridheroh (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ridingf (made by Tourniquet(Region Code)) [68EC020]
+ridingfj (made by Tourniquet(Region Code)) [68EC020]
+ridingfu (made by Tourniquet(Region Code)) [68EC020]
+ringking (made by ShimaPong) [Z80]
+ringking2 (made by ShimaPong) [Z80]
+ringking3 (made by ShimaPong) [Z80]
+ringkingw (made by ShimaPong) [Z80]
+ringrage (made by Tourniquet(Region Code)) [68EC020]
+ringragej (made by Tourniquet(Region Code)) [68EC020]
+ringrageu (made by Tourniquet(Region Code)) [68EC020]
+ripoff (made by Pugsy) [CCPU]
+roadf (made by ShimaPong) [M6809]
+roadf2 (made by ShimaPong) [M6809]
+roadrunn (made by Pugsy) [68010]
+roadrunn1 (made by Pugsy) [68010]
+roadrunn2 (made by Pugsy) [68010]
+robby (made by ugetab & ShimaPong) [Z80]
+roboarmy (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+robokid (made by ShimaPong) [Z80]
+robokidj (made by ShimaPong) [Z80]
+robokidj2 (made by ShimaPong) [Z80]
+robotron (made by Pugsy) [M6809]
+robotronyo (made by Pugsy) [M6809]
+rockduck (made by Pugsy) [M6502]
+roldfrog (made by ShimaPong) [68000]
+roldfroga (made by ShimaPong) [68000]
+rollingc (made by Pugsy) [8080]
+rongrong (made by RedBeam) [Z80]
+rongrongg (made by RedBeam) [Z80]
+rongrongj (made by RedBeam) [Z80]
+rotaryf (made by ShimaPong) [8085A]
+rotd (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+rotd (made by Pugsy) [68000]
+rougien (made by Pugsy) [Z80]
+route16 (made by Pugsy) [Z80]
+route16a (made by Pugsy) [Z80]
+route16b (made by Pugsy) [Z80]
+routex (made by Pugsy) [Z80]
+rpatrol (made by ShimaPong) [Z80]
+rpatrolb (made by ShimaPong) [Z80]
+rranger (made by Pugsy) [Z80]
+rtype (made by Jym) [V30]
+rtypeb (made by Jym) [V30]
+rtypej (made by Jym) [V30]
+rtypejp (made by Jym) [V30]
+rtypeu (made by Jym) [V30]
+rugrats (made by ShimaPong) [Z80]
+rundeep (made by ShimaPong) [Z80]
+rushatck (made by Pugsy) [Z80]
+rygar (made by ShimaPong) [Z80]
+rygar2 (made by ShimaPong) [Z80]
+rygar3 (made by ShimaPong) [Z80]
+rygarj (made by ShimaPong) [Z80]
+s1945p (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+saiyugou (made by ShimaPong) [HD6309]
+saiyugoub1 (made by ShimaPong) [HD6309]
+saiyugoub2 (made by ShimaPong) [HD6309]
+samsh5sh (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+samsh5sn (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+samsh5sp (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+samsho (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+samsho2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+samsho2k (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+samsho3 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+samsho3a (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+samsho4 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+samsho4k (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+samsho5 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+samsho5b (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+samsho5h (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+samshoh (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+samurai (made by Pugsy) [Z80]
+sasuke (made by ShimaPong) [M6502]
+savagere (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+savagere (made by ShimaPong) [68000]
+sb2003 (made by Pugsy) [E1-32XT]
+sb2003a (made by Pugsy) [E1-32XT]
+sboblbob (made by Pugsy) [Z80]
+sbuggera (made by Pugsy) [8085A]
+scfinals (made by Tourniquet(Region Code)) [68EC020]
+schaser (made by Pugsy) [8080]
+schasercv (made by Pugsy) [8080]
+scion (made by ShimaPong) [Z80]
+scionc (made by ShimaPong) [Z80]
+scobra (made by Pugsy) [Z80]
+scobrab (made by Pugsy) [Z80]
+scobras (made by Pugsy) [Z80]
+scobrase (made by Pugsy) [Z80]
+scorpion (updated/fixed by ShimaPong) [Z80]
+scorpiona (updated/fixed by ShimaPong) [Z80]
+scorpionb (updated/fixed by ShimaPong) [Z80]
+scorpionmc (updated/fixed by ShimaPong) [Z80]
+scramb2 (made by Pugsy) [Z80]
+scramblb (made by Pugsy) [Z80]
+scramble (made by Pugsy) [Z80]
+scramblebf (made by Pugsy) [Z80]
+scrambles (made by Pugsy) [Z80]
+scregg (made by Pugsy) [M6502]
+sdodgeb (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+sdungeon (made by ShimaPong) [M6809]
+searthin (made by Pugsy) [8080]
+searthina (made by Pugsy) [8080]
+seganinj (made by ShimaPong) [Z80]
+seganinju (made by ShimaPong) [Z80]
+sengokh (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+sengoku (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+sengoku2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+sengoku2 (made by ShimaPong) [68000]
+sengoku3 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+senjyo (made by ShimaPong) [Z80]
+sf (made by ShimaPong) [68000]
+sfj (made by ShimaPong) [68000]
+sflush (made by ShimaPong) [M6800]
+sfp (made by ShimaPong) [68000]
+sfu (made by ShimaPong) [68000]
+sfua (made by ShimaPong) [68000]
+sfx (made by ShimaPong) [Z80]
+sgladiat (made by ShimaPong) [Z80]
+shangkid (made by ShimaPong) [Z80]
+shangon (made by ShimaPong & Pugsy (acceleration)) [68000]
+shangon1 (made by ShimaPong) [68000]
+shangon2 (made by ShimaPong & Pugsy (acceleration)) [68000]
+shangon3 (made by ShimaPong & Pugsy (acceleration)) [68000]
+shangonle (made by ShimaPong & Pugsy (acceleration)) [68000]
+shangonrb (made by ShimaPong & Pugsy (acceleration)) [68000]
+shangonro (made by ShimaPong & Pugsy (acceleration)) [68000]
+shaolinb (made by Pugsy) [M6809]
+shaolins (made by Pugsy) [M6809]
+shdancbl (Invincibility made by ShimaPong/Level Select by Pugsy) [68000]
+shdancer (Invincibility made by ShimaPong/Level Select by Pugsy) [68000]
+shdancer1 (Invincibility made by ShimaPong/Level Select by Pugsy) [68000]
+shdancerj (Invincibility made by ShimaPong/Level Select by Pugsy) [68000]
+shikigam (made by Pugsy) [PSX CPU]
+shinobi (made by ShimaPong) [68000]
+shinobi1 (made by ShimaPong) [68000]
+shinobi2 (made by ShimaPong) [68000]
+shinobi3 (made by ShimaPong) [68000]
+shinobi4 (made by ShimaPong) [68000]
+shinobi5 (made by ShimaPong) [68000]
+shinoblb (made by ShimaPong) [68000]
+shinobld (made by ShimaPong) [68000]
+shinobls (made by ShimaPong) [68000]
+shocktr2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+shocktra (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+shocktro (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+shollow (made by ShimaPong) [Z80]
+shollow2 (made by ShimaPong) [Z80]
+shootout (made by ugetab) [M6502]
+shootoutb (made by ugetab) [M6502]
+shootoutj (made by ugetab) [M6502]
+shpeng (made by ShimaPong) [Z80]
+shuttlei (made by ShimaPong) [8080]
+sicv (made by Pugsy) [8080]
+silkroad (made by ShimaPong) [68EC020]
+silvland (made by ShimaPong) [Z80]
+sinistar (made by MRG) [M6809]
+sinistar1 (made by MRG) [M6809]
+sinistar2 (made by MRG) [M6809]
+sinvemag (made by Pugsy) [8080]
+sinvzen (made by Pugsy) [8080]
+sisv (made by Pugsy) [8080]
+sisv2 (made by Pugsy) [8080]
+sitv (made by Pugsy) [8080]
+skelagon (made by ShimaPong) [Z80]
+skyarmy (made by ShimaPong) [Z80]
+skybase (made by Pugsy) [Z80]
+skychut (made by ShimaPong) [M6502]
+skyfox (made by ShimaPong) [Z80]
+skylancr (made by ShimaPong) [Z80]
+skylancre (made by ShimaPong) [Z80]
+skylove (made by Pugsy) [8080]
+skyraidr (updated/fixed by ShimaPong) [Z80]
+skyshark (made by ShimaPong) [68000]
+skyskipr (made by Tourniquet) [Z80]
+skywolf (made by ShimaPong) [Z80]
+skywolf2 (made by ShimaPong) [Z80]
+skywolf3 (made by ShimaPong) [Z80]
+slapfigh (made by ShimaPong) [Z80]
+slapfigha (made by ShimaPong) [Z80]
+slapfighb1 (made by ShimaPong) [Z80]
+slapfighb2 (made by ShimaPong) [Z80]
+slapfighb3 (made by ShimaPong) [Z80]
+smash (made by Pugsy) [M6502]
+smashtv (made by Pugsy/ugetab) [TMS34010]
+smashtv4 (made by Pugsy/ugetab) [TMS34010]
+smashtv5 (made by Pugsy/ugetab) [TMS34010]
+smashtv6 (made by Pugsy/ugetab) [TMS34010]
+smooncrs (updated/fixed by ShimaPong) [Z80]
+snakepit (made by Pugsy) [M6809]
+snapjack (made by Pugsy) [Z80]
+socbrawl (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+socbrawlh (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+solarfox (made by Pugsy) [Z80]
+solarq (made by Pugsy) [CCPU]
+solfight (made by ShimaPong) [8080]
+solomon (made by Pugsy) [Z80]
+solomonj (made by Pugsy) [Z80]
+sonicbom (made by ShimaPong) [68000]
+sonicwi2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+sonicwi3 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+sonofphx (made by Shimapong) [Z80]
+sonson (made by Pugsy) [M6809]
+sonsonj (made by Pugsy) [M6809]
+sos (made by Pugsy) [8080]
+spacbat2 (updated/fixed by ShimaPong) [Z80]
+spacbatt (updated/fixed by ShimaPong) [Z80]
+spaceat2 (made by Pugsy) [8080]
+spaceatt (made by Pugsy) [8080]
+spacebrd (made by Pugsy) [Z80]
+spacecho (made by Pugsy) [Z80]
+spacecho2 (made by Pugsy) [Z80]
+spacedem (made by Pugsy) [Z80]
+spacedx (made by Pugsy) [68000]
+spacedxj (made by Pugsy) [68000]
+spacedxo (made by Pugsy) [68000]
+spacefb (made by Pugsy) [Z80]
+spacefbb (made by Pugsy) [Z80]
+spacefbg (made by Pugsy) [Z80]
+spaceftr (made by Pugsy) [CCPU]
+spaceg (made by ShimaPong) [Z80]
+spaceint (made by ShimaPong) [Z80]
+spaceintj (made by ShimaPong) [Z80]
+spacempr (updated by ShimaPong) [Z80]
+spaceph (made by ShimaPong) [8080]
+spacewar (made by Pugsy) [CCPU]
+spacewr3 (made by Pugsy) [8080]
+spacezap (made by Pugsy) [Z80]
+spacfury (made by Pugsy) [Z80]
+spacfurya (made by Pugsy) [Z80]
+spacfuryb (made by Pugsy) [Z80]
+spcdrag (updated/fixed by ShimaPong) [Z80]
+spcdraga (updated/fixed by ShimaPong) [Z80]
+spceking (made by Pugsy) [8080]
+spcewars (made by Pugsy) [8080]
+spcinv95 (made by Tourniquet(Region Code)) [68EC020]
+spcinv95u (made by Tourniquet(Region Code)) [68EC020]
+spcinvdj (made by Pugsy) [68EC020]
+spcking2 (made by Pugsy) [Z80]
+spcpostn (made by Pugsy) [Z80]
+spctbird (updated/fixed by ShimaPong) [Z80]
+speakres (made by Pugsy) [Z80]
+spectar (made by Pugsy) [M6502]
+spectar1 (made by Pugsy) [M6502]
+speedfrk (made by Pugsy) [CCPU]
+spfghmk2 (made by Pugsy) [M6502]
+spfghmk22 (made by Pugsy) [M6502]
+spiders (made by ShimaPong with bugfix by Pugsy) [M6809]
+spiders2 (made by ShimaPong with bugfix by Pugsy) [M6809]
+spiders3 (made by ShimaPong with bugfix by Pugsy) [M6809]
+spiero (made by Pugsy) [Z80]
+spinmast (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+spinner (made by ShimaPong with bugfix by Pugsy) [M6809]
+splash (made by ShimaPong) [68000]
+splash10 (made by ShimaPong) [68000]
+sprglbpg (made by ShimaPong) [Z80]
+sprglobp (made by ShimaPong) [Z80]
+springer (made by Pugsy) [Z80]
+sprint4 (made by Pugsy) [M6502]
+sprint4a (made by Pugsy) [M6502]
+sprint8 (made by Pugsy) [M6800]
+sqix (made by Pugsy) [Z80]
+sqixb1 (made by Pugsy) [Z80]
+sqixb2 (made by Pugsy) [Z80]
+sqixr1 (made by Pugsy) [Z80]
+sqixu (made by Pugsy) [Z80]
+sraider (made by ShimaPong) [Z80]
+sranger (made by Pugsy) [Z80]
+srangerb (made by Pugsy) [Z80]
+srangerw (made by Pugsy) [Z80]
+srdarwin (made by Pugsy) [M6809]
+srdarwinj (made by Pugsy) [M6809]
+srdmissin (made by ShimaPong) [Z80]
+ssideki (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ssideki2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ssideki3 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ssideki4 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+ssingles (made by ShimaPong) [???]
+sspacaho (made by Pugsy) [Z80]
+sspaceat (made by Pugsy) [Z80]
+sspaceat2 (made by Pugsy) [Z80]
+sspaceat3 (made by Pugsy) [Z80]
+sspaceatc (made by Pugsy) [Z80]
+sspeedr (made by Pugsy) [Z80]
+ssrj (made by Pugsy) [Z80]
+sstarbtl (made by ShimaPong) [M6502]
+sstingry (made by ShimaPong) [68000]
+sstrangr (made by Pugsy) [8080]
+sstrangr2 (made by Pugsy) [8080]
+stactics (made by ShimaPong) [8080]
+stakwin (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+stakwin2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+starcas (made by Pugsy) [CCPU]
+starcas1 (made by Pugsy) [CCPU]
+starcase (made by Pugsy) [CCPU]
+starcasp (made by Pugsy) [CCPU]
+starfir2 (made by PhantomDJ (Test Mode Fix) ) [Z80]
+starforc (made by ShimaPong) [Z80]
+starforca (made by ShimaPong) [Z80]
+starforcb (made by ShimaPong) [Z80]
+starforce (made by ShimaPong) [Z80]
+stargate (made by Pugsy) [M6809]
+starhawk (made by Pugsy) [CCPU]
+starjack (made by ShimaPong) [Z80]
+starjacks (made by ShimaPong) [Z80]
+starlstr (made by ShimaPong) [N2A03]
+startrek (made by Pugsy) [Z80]
+startrkd (made by Pugsy) [M6809]
+stellcas (made by Pugsy) [CCPU]
+stera (updated/fixed by ShimaPong) [Z80]
+stinger (made by ShimaPong) [Z80]
+stinger2 (made by ShimaPong) [Z80]
+stlforce (made by RedBeam) [68000]
+stoffy (made by ShimaPong) [M6809]
+stratgys (made by ShimaPong) [Z80]
+stratgyx (made by ShimaPong) [Z80]
+stratvox (made by Pugsy) [Z80]
+stratvoxb (made by Pugsy) [Z80]
+streakng (made by ShimaPong) [Z80]
+strfbomb (made by Pugsy) [Z80]
+strhoop (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+strongx (made by ShimaPong) [Z80]
+strtheat (made by Pugsy) [Z80]
+sub (made by Pugsy) [Z80]
+subroc3d (made by ShimaPong) [Z80]
+supcrash (made by Pugsy) [Z80]
+superg (made by Pugsy) [Z80]
+supergx (made by Pugsy) [Z80]
+superinv (made by Pugsy) [8080]
+superspy (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+suprglob (made by ShimaPong) [Z80]
+suprheli (made by Pugsy) [Z80]
+suprmatk (made by Pugsy) [M6502]
+suprmatkd (made by Pugsy) [M6502]
+supxevs (made by ShimaPong) [N2A03]
+sutapper (made by Pugsy) [Z80]
+suzume (made by ShimaPong) [Z80]
+svc (made by Kriptokapi/fixed by ShimaPong) [68000]
+svc (made by Pugsy {Generic neogeo RAM/ROM check} + no background music) [68000]
+svcboot (made by Kriptokapi/fixed by ShimaPong) [68000]
+svcboot (made by Pugsy {Generic neogeo RAM/ROM check} + no background music) [68000]
+svcpcb (made by Kriptokapi/fixed by ShimaPong) [68000]
+svcpcb (made by Pugsy {Generic neogeo RAM/ROM check} + no background music) [68000]
+svcpcba (made by Kriptokapi/fixed by ShimaPong) [68000]
+svcpcba (made by Pugsy {Generic neogeo RAM/ROM check} + no background music) [68000]
+svcplus (made by Pugsy {Generic neogeo RAM/ROM check} + no background music) [68000]
+svcplusa (made by Pugsy {Generic neogeo RAM/ROM check} + no background music) [68000]
+svcsplus (made by Pugsy {Generic neogeo RAM/ROM check} + no background music) [68000]
+swarm (made by Pugsy) [Z80]
+swimmer (made by ShimaPong) [Z80]
+swimmera (made by ShimaPong) [Z80]
+swimmerb (made by ShimaPong) [Z80]
+sxevious (made by ShimaPong) [Z80]
+sxeviousj (made by ShimaPong) [Z80]
+tactcian (made by Pugsy) [Z80]
+tactcian2 (made by Pugsy) [Z80]
+talbot (made by ShimaPong) [Z80]
+tankbatt (made by ShimaPong) [M6502]
+tapper (made by Pugsy) [Z80]
+tappera (made by Pugsy) [Z80]
+targ (made by Pugsy) [M6502]
+targc (made by Pugsy) [M6502]
+taxidrvr (made by ShimaPong) [Z80]
+tceptor (made by ShimaPong) [68000]
+tceptor2 (made by ShimaPong) [68000]
+tcobra2 (made by Tourniquet(Region Code)) [68EC020]
+tcobra2u (made by Tourniquet(Region Code)) [68EC020]
+teddybb (Invincibility made by ShimaPong/Time made by Pugsy) [Z80]
+teddybbo (made by ShimaPong/Time made by Pugsy) [Z80]
+teetert (made by Pugsy) [M6502]
+tekken (made by Pugsy) [PSX CPU]
+tekkena (made by Pugsy) [PSX CPU]
+tekkenb (made by Pugsy) [PSX CPU]
+tekkenc (made by Pugsy) [PSX CPU]
+tempest (made by Pugsy) [M6502]
+tempest1 (made by Pugsy) [M6502]
+tempest2 (made by Pugsy) [M6502]
+tempest3 (made by Pugsy) [M6502]
+temptube (made by Pugsy) [M6502]
+thedeep (made by ShimaPong) [Z80]
+theend (made by Pugsy) [Z80]
+theends (made by Pugsy) [Z80]
+theglob (made by ShimaPong) [Z80]
+theglob2 (made by ShimaPong) [Z80]
+theglob3 (made by ShimaPong) [Z80]
+theglobp (made by ShimaPong) [Z80]
+thepit (made by ShimaPong) [Z80]
+thepitb (made by ShimaPong) [Z80]
+thepitc (made by ShimaPong) [Z80]
+thepitm (made by ShimaPong) [Z80]
+theroes (made by RedBeam) [68000]
+thief (made by jym) [Z80]
+thunderx (made by Shimapong) [KONAMI]
+thunderxa (made by Shimapong) [KONAMI]
+thunderxb (made by Shimapong) [KONAMI]
+thunderxj (made by Shimapong) [KONAMI]
+tigerh (made by ShimaPong) [Z80]
+tigerhb1 (made by ShimaPong) [Z80]
+tigerhb2 (made by ShimaPong) [Z80]
+tigerhb3 (made by ShimaPong) [Z80]
+tigerhj (made by ShimaPong) [Z80]
+timber (made by ShimaPong) [Z80]
+tmht22pe (made by ShimaPong) [68000]
+tmnt2 (made by ShimaPong) [68000]
+tmnt22pu (made by ShimaPong) [68000]
+tmnt2a (made by ShimaPong) [68000]
+tndrcade (made by Pugsy) [68000]
+tndrcadej (made by Pugsy) [68000]
+toffy (made by ShimaPong) [M6809]
+tokia (made by Pugsy) [68000]
+tokib (made by Pugsy) [68000]
+tokij (made by Pugsy) [68000]
+tokio (made by ShimaPong) [Z80]
+tokiob (made by ShimaPong) [Z80]
+tokioo (made by ShimaPong) [Z80]
+tokiou (made by ShimaPong) [Z80]
+tokisens (made by ShimaPong) [Z80]
+tokiu (made by Pugsy) [68000]
+tokiua (made by Pugsy) [68000]
+topgun (made by ShimaPong) [N2A03]
+tophuntr (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+tophuntrh (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+toprollr (made by ShimaPong) [Z80]
+topsecrt (made by ShimaPong) [68000]
+toride2g (made by Pugsy) [68000]
+toride2gg (made by Pugsy) [68000]
+toride2j (made by Pugsy) [68000]
+tornado1 (made by Pugsy) [M6809]
+toucheme (made by Pugsy) [Z80]
+tp84 (made by ShimaPong) [M6809]
+tp84a (made by ShimaPong) [M6809]
+tp84b (made by ShimaPong) [M6809]
+tpgolf (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+trally (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+transfrm (made by ShimaPong) [Z80]
+trckydoc (made by ShimaPong) [Z80]
+trckydoca (made by ShimaPong) [Z80]
+trog (made by Pugsy) [TMS34010]
+trog3 (made by Pugsy) [TMS34010]
+trog4 (made by Pugsy) [TMS34010]
+trogp (made by Pugsy) [TMS34010]
+trogpa6 (made by Pugsy) [TMS34010]
+tron (Invincibility made by Pugsy - RAM/ROM check by ShimaPong) [Z80]
+tron2 (Invincibility made by Pugsy - RAM/ROM check by ShimaPong) [Z80]
+tron3 (Invincibility made by Pugsy - RAM/ROM check by ShimaPong) [Z80]
+tron4 (Invincibility made by Pugsy - RAM/ROM check by ShimaPong) [Z80]
+trstar (made by Tourniquet(Region Code)) [68EC020]
+trstarj (made by Tourniquet(Region Code)) [68EC020]
+trstaro (made by Tourniquet(Region Code)) [68EC020]
+trstaroj (made by Tourniquet(Region Code)) [68EC020]
+tsamurai (made by Pugsy) [Z80]
+tsamurai2 (made by Pugsy) [Z80]
+tsamuraih (made by Pugsy) [Z80]
+tubep (made by ShimaPong) [Z80]
+tubepb (made by ShimaPong) [Z80]
+tugboat (made by ShimaPong) [M6502]
+turfmast (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+turpin (made by ShimaPong) [Z80]
+turpins (made by ShimaPong) [Z80]
+turtles (made by ShimaPong) [Z80]
+tutankhm (made by Pugsy) [M6809]
+tutankhms (made by Pugsy) [M6809]
+twincobr (made by Jym/Pugsy) [68000]
+twincobru (made by Jym/Pugsy) [68000]
+twinhawk (made by Pugsy) [68000]
+twinhawku (made by Pugsy) [68000]
+twinqix (made by Tourniquet(Region Code)) [68EC020]
+twinspri (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+twotiger (made by ShimaPong) [Z80]
+twotigerc (made by ShimaPong) [Z80]
+tws96 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+tylz (made by Pugsy) [I8086]
+typhoon (made by ShimaPong) [KONAMI]
+ufosensi (made by ShimaPong) [Z80]
+ufosensib (made by ShimaPong) [Z80]
+umk3 (made by Steph/ugetab) [TMS34010]
+umk3r10 (made by Steph/ugetab) [TMS34010]
+umk3r11 (made by Steph/ugetab) [TMS34010]
+unclepoo (made by Pugsy) [Z80]
+uniwars (updated by ShimaPong) [Z80] 
+upndown (made by Pugsy) [Z80]
+upndownu (made by Pugsy) [Z80]
+vangrd2 (made by Pugsy) [Z80]
+vautour (made by Pugsy) [I8085A]
+vautourz (made by Pugsy) [Z80]
+venture (made by ShimaPong) [M6502]
+venture2 (made by ShimaPong) [M6502]
+venture4 (made by ShimaPong) [M6502]
+venus (made by Pugsy) [Z80]
+viewpoin (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+vliner (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+vlinero (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+vsgradus (made by ShimaPong) [N2A03]
+vsgshoe (made by Pugsy) [N2A03]
+vulcan (made by ShimaPong) [68000]
+vulcana (made by ShimaPong) [68000]
+vulcanb (made by ShimaPong) [68000]
+wacko (made by Pugsy) [Z80]
+wakuwak7 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+wallst (made by ugetab) [S2650]
+warpwarp (made by ShimaPong) [8080]
+warpwarpr (made by ShimaPong) [8080]
+warpwarpr2 (made by ShimaPong) [8080]
+warrior (made by Pugsy) [CCPU]
+wecleman (made by ShimaPong) [68000]
+wexpress (made by ShimaPong) [M6502]
+wexpressb (made by ShimaPong) [M6502]
+wexpressb2 (made by ShimaPong) [M6502]
+wh1 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+wh1h (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+wh1ha (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+wh2 (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+wh2j (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+wh2jh (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+whp (made by Pugsy {misc & Generic neogeo RAM/ROM check}) [68000]
+wilytowr (made by Pugsy) [Z80]
+wink (made by ShimaPong) [Z80]
+winka (made by ShimaPong) [Z80]
+wiping (made by ShimaPong) [Z80]
+wjammers (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+wonder3 (made by RedBeam) [68000]
+woodpek (made by ShimaPong) [Z80]
+wotw (made by Pugsy) [CCPU]
+wotwc (made by Pugsy) [CCPU]
+wrally (made by Pugsy) [68000]
+wrallya (made by Pugsy) [68000]
+wrallyb (made by Pugsy) [68000]
+wrecking (made by Pugsy) [N2A03]
+xevios (made by ShimaPong) [Z80]
+xevious (made by ShimaPong) [Z80]
+xeviousa (made by ShimaPong) [Z80]
+xeviousb (made by ShimaPong) [Z80]
+xeviousc (made by ShimaPong) [Z80]
+xmcota (made by RedBeam) [68000]
+xmcotaa (made by RedBeam) [68000]
+xmcotad (made by RedBeam) [68000]
+xmcotah (made by RedBeam) [68000]
+xmcotahr1 (made by RedBeam) [68000]
+xmcotaj (made by RedBeam) [68000]
+xmcotaj1 (made by RedBeam) [68000]
+xmcotaj2 (made by RedBeam) [68000]
+xmcotaj3 (made by RedBeam) [68000]
+xmcotajr (made by RedBeam) [68000]
+xmcotau (made by RedBeam) [68000]
+xmultipl (made by ShimaPong) [V30]
+xmultiplm72 (made by ShimaPong) [V30]
+xmvsf (made by Pugsy) [68000]
+xmvsfa (made by Pugsy) [68000]
+xmvsfar1 (made by Pugsy) [68000]
+xmvsfar2 (made by Pugsy) [68000] {different region than others - look at changing others to match, should be better}
+xmvsfb (made by Pugsy) [68000]
+xmvsfh (made by Pugsy) [68000]
+xmvsfj (made by Pugsy) [68000]
+xmvsfjr1 (made by Pugsy) [68000]
+xmvsfjr2 (made by Pugsy) [68000]
+xmvsfr1 (made by Pugsy) [68000]
+xmvsfu (made by Pugsy) [68000]
+xmvsfu1d (made by Pugsy) [68000]
+xmvsfur1 (made by Pugsy) [68000]
+xxmissio (made by ShimaPong) [Z80]
+yachtmn (made by ShimaPong) [Z80]
+yamato (made by ShimaPong) [Z80]
+yamato2 (made by ShimaPong) [Z80]
+yankeedo (made by Pugsy) [Z80]
+yellowcb (made by Pugsy) [DECO CPU16]
+yellowcj (made by Pugsy) [DECO CPU16]
+yiear (made by ShimaPong) [M6809]
+yiear2 (made by ShimaPong) [M6809]
+zedblade (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+zektor (made by Pugsy) [Z80]
+zero (made by Pugsy) [M6809]
+zero2 (made by Pugsy) [M6809]
+zerohour (made by ShimaPong) [Z80]
+zerotime (made by Pugsy) [Z80]
+zerotrgt (made by Pugsy) [M6809]
+zigzag (made by Pugsy/improved (3 to 2 part) by ShimaPong) [Z80]
+zigzag2 (made by Pugsy/improved (3 to 2 part) by ShimaPong) [Z80]
+zintrckb (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+zipzap (made by ShimaPong) [68000]
+zoar (made by Pugsy) [M6502]
+zodiack (made by ShimaPong) [Z80]
+zookeep (made by Pugsy) [M6809]
+zookeep2 (made by Pugsy) [M6809]
+zookeep3 (made by Pugsy) [M6809]
+zoom909 (made by ShimaPong) [Z80]
+zupapa (made by Pugsy {Generic neogeo RAM/ROM check}) [68000]
+
+------------------------------------------------------------------------------
+   SECTION 10     Games utilising EEPROM/Mapped Memory cheats with credits
+------------------------------------------------------------------------------
+
+This is a list of games that currently make use of cheats that poke direct to
+mapped memory or EEPROM. Generally these cheats are to reveal game functions
+such as hidden game characters. Note: If the mapped memory being poked is
+actually program code it is classed as a ROM cheat!
+
+EEPROM
+gunbird2 [Unlock Aine] (Found by Tourniquet)
+s1945iii [Unlock X-36] (Found by Tourniquet)
+sailormn/sailormno [REGION] (Found by either sum or zanhsieh - REPLACED WITH STANDARD CHEATS 0.126)
+sfa3/sfa3b/sfa3u/sfa3ur1/sfz3a/sfz3ar1/sfz3j/sfz3jr1/sfz3jr2 [Colour Unlock] (Found by RedBeam)
+
+Mapped Memory
+sb2003 + sb2003a [EEPROM region] (Found by unknown)
+mk3 + clones [Unlock Smoke] (Found by Tourniquet) [CHEAT DISABLED - NO LONGER WORKS, replaced with alternative character cheat]
+umk3 + clones [Unlock Secret Chars] (Found by Tourniquet) [CHEAT DISABLED - NO LONGER WORKS, replaced with alternative character cheat]
+kof99 + clones [Unlock Secret Chars] (Found by unknown) [CHEAT DISABLED - NO LONGER WORKS, replaced with enable character cheat]
+
+------------------------------------------------------------------------------
+       SECTION 11     Games utilising Forced Range cheats with credits
+------------------------------------------------------------------------------
+
+This is a list of the games currently make use of the force range type cheat as
+added in the new cheat engine. It basically allows you to take a location and
+make sure that the value stays within a range of values. An example is Arkanoid
+where by finding the Y pos of the ball sprite we can ensure by a simple cheat
+that the ball never leaves the playing area as soon as it attempts to we poke
+the location with a value which will effectively push the ball up a bit so that
+you can have another go at hitting the ball. They will hopefully used more in
+future as people understand them.
+
+4in1boot (found by Pugsy)
+ark1ball (found by Pugsy)
+arkangc (found by Pugsy)
+arkangc2 (found by Pugsy)
+arkanoid (found by Pugsy)
+arkanoidj (found by Pugsy)
+arkanoidu (found by Pugsy)
+arkanoiduo (found by Pugsy)
+arkatayt (found by Pugsy)
+arkatour (found by Pugsy)
+arkbloc2 (found by Pugsy)
+arkbloc3 (found by Pugsy)
+arkblock (found by Pugsy)
+arkgcbl (found by Pugsy)
+arkgcbla (found by Pugsy)
+arkmcubl (found by Pugsy)
+arkretrn (found by Pugsy)
+arktayt2 (found by Pugsy)
+armwrest (found by Pugsy)
+bestri (found by Pugsy)
+block2 (found by Pugsy)
+bombbee (found by Pugsy)
+cannonb (found by Pugsy)
+cannonb2 (found by Pugsy)
+catt (found by Pugsy)
+cflyball (found by ShimaPong)
+cgraplop (found by ShimaPong)
+cgraplop2 (found by ShimaPong)
+cham24 (found by Pugsy)
+circus (found by ugetab)
+cotton (found by ShimaPong)
+cottonj (found by ShimaPong)
+cottonu (found by ShimaPong)
+cutieq (found by Pugsy)
+drakton (found by Pugsy)
+freekckb (found by Pugsy)
+freekick (found by Pugsy)
+funkyjet (found by ugetab)
+funkyjetj (found by ugetab)
+funystrp (found by ShimaPong)
+geebee (found by Pugsy)
+geebeeg (found by Pugsy)
+gensitou (found by ShimaPong)
+gigasb (found by Pugsy)
+gigasm2b (found by Pugsy)
+goindol (found by Pugsy)
+goindolj (found by Pugsy)
+goindolu (found by Pugsy)
+grindstm (found by ShimaPong)
+grindstma (found by ShimaPong)
+homo (found by Pugsy)
+legion (found by ShimaPong)
+legiono (found by ShimaPong)
+madball (found by Pugsy)
+madballn (found by Pugsy)
+mcatadv (found by Pugsy)
+mcatadvj (found by Pugsy)
+mt_eswat (found by ShimaPong)
+mustang (found by ShimaPong)
+mustangb (found by ShimaPong)
+mustangs (found by ShimaPong)
+neobattl (found by Pugsy)
+nmouse (found by Pugsy)
+nmouseb (found by Pugsy)
+ohmygod (found by Pugsy/mike_myers)
+oigas (found by Pugsy)
+paddle2 (found by Pugsy)
+pinbo (found by ShimaPong)
+pinboa (found by ShimaPong)
+pinbos (found by ShimaPong)
+pipibibi (found by Pugsy)
+pipibibs (found by Pugsy)
+pipibibsa (found by Pugsy)
+popbounc (found by Pugsy)
+prehisleu (found by ShimaPong)
+preshisle (found by ShimaPong)
+puchicar (found by Pugsy)
+puchicarj (found by Pugsy)
+puckpepl (found by ShimaPong)
+pzlbreak (found by Pugsy)
+quester (found by ugetab)
+quiz18k (found by Pugsy)
+radm (found by Pugsy)
+radmu (found by Pugsy)
+radr (found by Pugsy)
+radru (found by Pugsy)
+sbrkout (found by Pugsy)
+snowbros (found by Pugsy)
+snowbros3 (found by Pugsy)
+snowbrosa (found by Pugsy)
+snowbrosb (found by Pugsy)
+snowbrosc (found by Pugsy)
+snowbrosj (found by Pugsy)
+spyhunt2 (found by ugetab)
+spyhunt2a (found by ugetab)
+tenkomorj (found by ShimaPong)
+twinactn (found by ShimaPong)
+twinsqua (found by ShimaPong)
+ufosensi (found by ShimaPong)
+ufosensib (found by ShimaPong)
+vasara (found by ShimaPong)
+vasara2 (found by ShimaPong)
+vasara2a (found by ShimaPong)
+vfive (found by ShimaPong)
+wallc (found by Pugsy)
+wallca (found by Pugsy)
+whoopee (found by Pugsy)
+wintbob (found by Pugsy)
+
+------------------------------------------------------------------------------
+SECTION 12   Games utilising Dynamic (Relative Addressing) cheats with credits
+------------------------------------------------------------------------------
+
+This is a list of games that currently use 'dynamic' cheats. Dynamic cheats
+are basically just relative addressed cheats. The problem with some games when
+you do a cheat search is that you can easily find for example the energy
+location and poking it will seem to work fine, but if you advance a level you
+will find that the cheat no longer works. In fact the next time you play the
+level you found the cheat for you will probably find that the cheat doesn't
+work there either. I've included my method of how to find your own 'dynamic'
+cheats under this list...enjoy ;-) Again this list is sorted in the order that
+cheats were added (oldest cheats first).
+
+samsho (found by Pugsy)
+kabukikl (found by Pugsy/+ Magic found by ShimaPong)
+samsho2/samsho2k (found by Pugsy)
+savagere (found by Pugsy/ + Invincibility by ShimaPong)
+lastblad/lastbladh/lastsold (found by Pugsy)
+3countb (found by Pugsy)
+lastbld2 (found by Pon)
+dadandrn/mmaulers (found by Tourniquet)
+ncv2/ncv2j (found by Pugsy)
+galaxyfg (found by KelvSYC)
+gunhohki/mysticri/mysticrib (found by ShimaPong)
+ncv1/ncv1j/ncv1j2 (found by ShimaPong)
+kengo (found by ShimaPong)
+rdft2/rdft2a/rdft2a2/rdft2j/rdft2t/rdft22kc/rdft2us (found by ShimaPong)
+tenkomorj/tenkomor (found by ShimaPong)
+vamphalf (found by ShimaPong)
+danceyes (found by ShimaPong)
+mmatrix/mmatrixd/mmatrixj (found by ShimaPong)
+prikura (found by ShimaPong)
+rsgun (found by ShimaPong)
+tophuntr/tophuntrh (found by ShimaPong)
+neobombe (found by ShimaPong)
+dreamwld (found by Pugsy)
+avsp/avspa/avsph/avspj/avspu (found by RedBeam)
+punisher/punisherj/punisheru/punipic/punipic2/punipic3 {punipic/punipic2/punipic3 untested} (found by RedBeam)
+gunforce/gunforcej/gunforceu (found by Pugsy)
+
+------------------------------------------------------------------------------
+              SECTION 13     Games which may use the same cheats
+------------------------------------------------------------------------------
+ Basically this is an alphabetical list of clones, so even although area88
+ is a clone of UN Sqauadron it is listed after area88. Also some of the
+ games are not listed by MAME as clones but they are, at least from the
+ perspective of cheats - which is why this is here!
+
+ =  means the game uses the same cheats as the game listed before it.
+
+ ~  means the game uses slightly different cheats than the game listed
+    before it.
+
+ ~= means the game uses cheats which are the same AND some are slightly
+    different than the game listed before it
+
+   This list of clones will always be based on the latest version of MAME
+   be it a BETA or a FINAL release that is covered by the cheat file!!
+   Almost inevitably this clone list will contain errors, due to the nature
+   of it being updated as an afterthought and being manually updated.
+
+  If there are cheats for non-working clones (and so they are untested)
+  then a comment should be added to that effect in this list so that the
+  game entry need not have untested in it, in most cases clones will work
+
+   This list of clones is only valid for RAM cheats - ROM cheats and dip
+   switches vary too frequently between games.
+
+005~=(monsterb2=monsterb)~=(spaceod=spaceod2)
+10yard=10yard85=10yardj=vs10yard=vs10yardj=vs10yardu
+1941=1941j
+1942=1942a=1942abl=1942b=1942w
+1943=1943j=1943kai=1943u
+1944=1944d=1944j (1944d to be checked)
+19xx=19xxa=19xxb=19xxd=19xxh=19xxj=19xxjr1
+2020bb=2020bba=2020bbh
+20pacgal=20pacgalr1=20pacgalr2=20pacgalr4
+3wonders=3wondersu=wonder3
+47pie2=47pie2o
+4in1~=warofbug&scramble&ghostmun
+600~turpin=turpins=turtles
+64streetj=64street
+720=720g=720gr1=720r1=720r2=720r3
+7jigen~=neruton~(mjangels=yarunara=mjcomv1)
+7toitsu=mgakuen~=mgakuen2
+800fath=mariner~=(scramblb~=explorer=scramb2=scramble=strfbomb~=scrambles)~=(scobra=scobrase~=(scobrab=scobras))
+88games=hypsptsp=konami88
+8ball=8ball1
+8ballact=8ballact2~8bpm
+99lstwar=repulse=sonofphx~=99lstwara~=99lstwark
+9ballsht2~9ballsht3~9ballsht~coolpool
+aafb~=aafbd2p~=(aafbb=aafbc)
+abaseb=abaseb2
+abattle=abattle2=acombat=acombato=afire=astrof=astrof2=astrof3=sstarbtl
+aburner~=aburner2
+aceattaca=aceattac (unchecked aceattac - not working)
+acitya~bwcasino
+actfancr1=actfancrj=actfancr
+aerfboo2=aerfboot=aerofgtb=aerofgtc=sonicwi~aerofgt
+aeroboto=formatz
+aerofgts~=sncwgltd (differences in Afxxx addresses)
+agallet=agalleth=agalletj=agalletk=agallett=agalletu
+agentx1~=agentx2~=agentx3~=(agentx4=cloak=cloakfr=cloakgr=cloaksp)  [inf credits diff location]
+agress=agressb
+airattcka=airattck=ssmissin=tdragon~=(tdragon1~=tdragonb) {credit location & credit max value only differences}
+airbustrb=airbustrj=airbustr
+aircombj=aircomb
+airraid~=(cshooter=cshootere) {relationship not fully checked as game not really working}
+airwolf=skywolf=skywolf2=skywolf3
+ajax=ajaxj=typhoon
+akkanvdr=spcinv95=spcinv95u
+alcon=slapfighb1=slapfighb2=slapfighb3=slapfigha=slapfigh
+alexkidd1=alexkidd
+alien3=alien3u
+alienar=alienaru
+aliencha~alienchac (offset by 2)
+alieninv=alieninvp2=cosmicm2=cosmicmo=invaddlx=invader4=invaderl=invaders=invadpt2=invadrmr=jspecter=jspecter2=moonbase=moonbasea=searthina=searthin=sicv=sinvemag=sinvzen=sisv=sisv2=sitv=spaceat2=spaceatt=spacewr3=spceking=spcewars=sstrangr=sstrangr2=superinv=invasion=invasiona~=invasionb=invasionrz~=invasionrza~(polaris=polarisa=polariso)~(highsplt=highsplta=highspltb=spacefev=spacefevo=spacefevo2~=spacelnc)~darthvdr (invasionb/rz/rza have different shield designs)
+aliens=aliens2=aliens3=aliensa=aliensj=aliensj2=aliensu
+aliensec=baraduke
+aliensyn=aliensyn2=aliensyn3=aliensyn5=aliensynj=aliensynjo
+aligator=aligatorun
+alphamis=aso~=arian
+alphaonea~alphaone=(mhavoc=mhavoc2=mhavocp=mhavocrv)
+alphaxz=m660=m660b=m660j
+alpine=alpinea
+alpinerc=alpinerd~alpinr2b
+altair~destryera~destryer
+altbeast5=altbeast=altbeast2=altbeastj=altbeastj2=altbeastj1=altbeastj3=altbeast4        (altbeastj1 & altbeastj2 untested as NOT working)
+amatelas~=amazon
+ambush=ambushv~=ambushj
+amerdart=amerdart2=amerdart3 (unchecked relationship)
+amidar=amidarb=amidaro=amidaru=amigo~=amidars
+ampoker2=ampkr2b1=ampkr2b2=ampkr2b3=videomat (unchecked relationship)
+amspdwy=amspdwya
+animaljr=animaljrs~animaljrj
+anteater~(anteatg=anteatgb)
+aof2=aof2a
+aof3=aof3k
+apache3=apache3a
+apb=apb2=apb3=apb4=apb5=apb6=apbf=apbg~=apb1
+aponow=rescue
+apparel=citylove~=secolove
+aquajack=aquajackj
+arabfgt=arabfgtj=arabfgtu
+arabian=arabiana
+arabianmj=arabianmu=arabianm
+aracnis=scorpion=scorpionmc=scorpiona=scorpionb
+arcadia=nyny=nynyg
+archrivl2=archrivl
+area51=area51a~(a51mxr3k~a51r3k)
+area88=unsquad
+ark1ball=arkangc=arkangc2=arkanoid=arkanoiduo=arkatayt=arkatour=arkbloc2=arkbloc3=arkblock=arkgcbl=arkgcbla=arkmcubl=arkanoidu=arktayt2=block2~=arkanoidj=paddle2
+arknoid2j=arknoid2u=arknoid2
+armchmp2o=armchmp2
+armedf=armedff
+armora=armorap=armorar
+armorcar=armorcar2
+armwar=armwar1d=armwara=armwarr1=armwaru=armwaru1=pgear=pgearr1
+ar_airh=ar_airh2
+ar_dart=ar_dart2
+ar_ldrb=ar_ldrba
+ar_ninj=ar_ninj2
+ar_sdwr=ar_sdwr2
+ashnojoe~=scessjoe (minor difference with inf credits cheat as ashnojoe needs a comment)
+ashura~=ashuraj~=ashurau
+asoccer=idsoccer=idsoccera
+assault~=assaultj~=assaultp (values differ)
+astdelux1=astdelux2~=astdelux (credits location differ)
+asterix=asterixj=asterixaad=asterixeaa=asterixeac
+asterock=(asteroid1=meteorho=meteorts)~=(asteroid2=asteroidb=asteroid)
+astinvad=kamikaze
+astorm=astormj~=(astorm3~=astormu)~(astormb2=astormbl)  {No delay for extra weapon PLx needed for astormu)
+astrob=astrob2a~(astrob1=astrob2=astrobg)
+astrofl=transfrm
+astyanax~=lordofk
+asuka=asukaj
+asurabld~=asurabus (asurabus missing lots of cheats in asurabld - needs duplicating)
+atarifb=atarifb1=atarifb4
+ataxx~=ataxxa~=ataxxj
+atetrisc2=atetrisc=atetris=atetrisa=atetrisb=atetrisb2
+atlantis~atlantis2~=atlantisb
+atlantol~=(hyprolymb=hyprolym=trackfldc=trackfld)  {atlantol has just 2 players}
+atomboy=atomboya=wilytowr
+atompunk=dynablst=~dynablstb~=bombrman~=(bbmanw=bbmanwj=bomblord=newapunk)
+aurail=aurail1=aurailj
+automat=robocop=robocopb=robocopj=robocopw~=(robocopu=robocopu0) (max credits value only difference so far)
+av2mj1bb=av2mj2rg=galkoku=galkaika=hyouban=mcontest=mjlstory=ntopstar=pstadium=tokimbsj=tokyogal=triplew1=triplew2=uchuuai
+avalnche=cascade
+avengers2=avengers=buraiken
+avengrgsj=avengrgs
+avsp=avspa=avspd=avsph=avspj=avspu
+avspirit=monkelf {monkelf untested}
+backfirea=backfire
+baddudes=drgninja
+badlands=badlandsb (badlandsb unchecked - not working)
+bagman=bagmanf=bagmanmc=bagmans=bagmans2=bagnard=bagnarda~=sbagman=sbagmans (sbagman(s) has a gun cheat)
+bakubrkr=explbrkr
+bakuhatu=mjgottsu~(cmehyou=ngpgal)~(finalbny=mjgottub=mjkoiura=mjuraden=mkoiuraa=qmhayaku=vanilla)~mmehyou
+bananadr=hanamomb=hanamomo=mgmen89=mjcamera=mjfocus=mjfocusm=mmcamera=mmcamerb=msjiken=peepshow~=idhimitu~=(mjsikakb=mjsikakc=mjsikakd=mjsikaku)~=(scandal=scandalm=telmahjn)~(kanatuen~=kyuhito~=otonano)
+banbam=pettanp
+bandido=sheriff
+bang=bangj
+bangball~=batlbubl
+barricad=brickyrd
+bass=getbass (unchecked relationship)
+bassang2~bassangl~fbaitbc~(fbaitmc=fbaitmca=fbaitmcj=fbaitmcu)~fbait2bc
+batcir=batcira=batcird=batcirj
+batlballa=batlball=batlballu~senkyu~senkyua
+batman2=phoenxp2~=condor~=(falcon=falconz=nextfase=phoenix=phoenix3=phoenixa=phoenixb=phoenixc=phoenixj=phoenixt=vautour=vautourz(pleiads~capitol=pleiadce=pleiadbl))~=griffon
+batrid=batridc=batridj=batridja=batridk=batridta=batridu
+batsuguna=batsugun=batsugunsp
+battlane=battlane2=battlane3
+battlera=bldwolf=bldwolfj
+battles=xevios~=(sxevious=sxeviousj)~=xevious~=(xeviousa=xeviousb=xeviousc)
+battlntsj=battlnts
+bayroute1=bayroute=bayroutej=bayrouteb1=bayrouteb2
+bbros=pang=pangb=pangba=pangbold=pompingw
+bbusters=bbustersu
+bchopper=mrheli
+bcrusher=kncljoe=kncljoea
+bcstry=bcstrya
+beaminv~beaminva
+beastf~suprglob~(theglob=theglob2~theglob3)~(sprglbpg=sprglobp=theglobp)
+beastrzb=beastrzr~=bldyroar (credits difference)
+beezer~=beezer1
+berabohm=berabohmo
+berlwall~=berlwallt
+bermudata=worldwar~=(bermudatj=bermudat)
+berzerk=berzerk1=berzerkg
+bestleag=bestleaw=bigstrik=bigstrkb
+bgareggacn=bgaregganv=bgareggat2~=bgareggabgareggahk=bgareggatw=
+bigbang=tdragon2a=tdragon2~=raphero
+bigdeal=bigdealb (unchecked relationship)
+bigevglf=bigevglfj
+bigfghtr=skyrobo
+bigkong=ckong=ckongpt2=ckongpt2j=ckongpt2a=ckongalc=ckongpt2b=ckongg=ckongpt2jeu=ckongo=ckongs=dkongf=dkongj=dkongjo=dkongjo1=ckongmc=monkeyd~=(dkong=dkongo) {level order differences}
+bigprowr=tagteam
+bigrun~=cischeat
+bijokkog=bijokkoy
+billiard=hustler=hustlerb=hustlerb2=vpool
+bionicc=bionicc1=bionicc2=topsecrt
+bioship=sbsgomo
+bjtwin=bjtwina
+bking=bking2~=bking3
+bkraidu=bkraiduj=bkraidj
+bladestl=bladestle=bladestll
+blandia~blandiap
+blaster30~=blaster=blasterkit (difference in level extra comment)
+bldyror2=bldyror2a=bldyror2j=bldyror2u
+blitz~=blitz11~=blitz2k~=blitz99 (unchecked relationship)
+blkbustr=crazyblk=mrjong
+blkheartj=blkheart
+blktigerb1=blktigerb2=blkdrgonb=blkdrgon=blktiger
+blktouch=drgpunch=inca=maya
+blmbycar=blmbycaru
+block=blockbl=blockj=blockjoy
+blockade~=mineswpr
+blockgalb=blockgal
+blockhl=quarth
+blockout2=blockoutj~=blockout
+bloodbro=bloodbroa=bloodbrob=hrdtimesa=hrdtimes=weststry
+bloodstm11=bloodstm21=bloodstm22=bloodstm
+bloodwar=oedfight
+bloxeed=bloxeedc=bloxeedu
+blstroidh=blstroid2=blstroid3=blstroid=blstroidg
+blswhstl=detatwin
+bluehawk=bluehawkn
+blueprntj=blueprnt
+bmaster=crossbld
+bnj=brubber=caractn
+bnstars~=bnstars1 {difference is bnstars has only got one screen)
+bnzabros=bnzabrosj
+boblbobl=bub68705=bublboblr1=bublbobl1=bublbobl=dland=missb2~=bublboblr~=sboblboa=sboblbob
+bodyslam=dumpmtmt
+boggy84=boggy84b~=(fastfred=flyboy=flyboyb)~=(jumpcoas=jumpcoast)
+bombbee~=(geebee=geebeeb=geebeeg)
+bombjack2=bombjack
+bonzeadvo=bonzeadvu=bonzeadv=jigkmgri
+boobhack=horekid=horekidb
+boogwinga=boogwing=ragtime=ragtimea
+boomrang=boomranga
+bootcamp=combatsc=combatscb=combatsct=combatscj
+bosco=boscomd=boscomdo=boscoo=boscoo2
+botss~botssa
+bottom9=bottom9n~=mstadium
+bouldash=bouldashj
+boxyboy=soukobdx
+bradley~=(bzone=bzone2)~=bzonec
+brapboysj=brapboys (unchecked relationship - both reason1)
+brdrlinb=brdrline=brdrlins
+breakers~breakrev
+breywood=shackled
+brival=brivalj
+brix=zzyzzyxx2=zzyzzyxx
+brkthru=brkthruj=forcebrk
+bronx=cyclshtg (unchecked relationship)
+brvblade=brvbladea=brvbladej=brvbladeu
+bshark=bsharkj
+bstars=bstarsh
+btime=btime2=btimem=cbtime~=cookrace
+btlfield=btlfieldb=skyadvntj=skyadvnt=skyadvntu~=(timesold1=timesold~=skysoldr)
+bubblem=bubblemj
+bubbles=bubblesp=bubblesr
+bubl2000=hotbubl
+bublbob2=bubsymphb=bubsymphb=bubsymphe=bubsymphj=bubsymphu
+buccanrsa~=buccanrs
+buckrog=buckrogn~zoom909
+bucky=buckyaa=buckyua
+buggyboyjr~=buggyboy
+buggychl=buggychlt
+bullfgt=thetogyu
+bullfgtr=bullfgtrs
+bullsdrt~=porky
+burnforc=burnforco
+burningf=burningfh
+buzzard=gyrodinet=gyrodine
+bwings=bwingsa=bwingso
+cabal=cabala=cabalbl=cabalbl2=cabalus=cabalus2
+cachat=tubeit
+cactus=sabotenb=sabotenba
+cadash=cadashf=cadashg=cadashi=cadashj=cadashu
+calorie=calorieb
+calspeeda=calspeed (unchecked relationship)
+cameltryj=cameltry=cameltryau=cameltrya
+canbprot=canyon
+candance=osman
+cannball~=cannballv {credits only address the same}
+cannonb=cannonb2~=cannonb3~cannonbp  (cannonb3 has no bonus game)
+capbowl=capbowl2=clbowl~=(capbowl3=capbowl4)  (inf credits diff)
+captaven=captavena=captavene=captavenj=captavenu=captavenua=captavenuu
+captcomm=captcommb=captcommj=captcommjr1=captcommr1=captcommu
+carnevil~carnevil1
+carnival=carnivalc=carnivalh=carnivalha
+catch22=combat
+caterplr=centiped2=centipdb=centiped=magworm=millpac~=centtime
+catnmousa=catnmous (unchecked relationship)
+catt=mcatadv=mcatadvj
+cawing=cawingj=cawingr1=cawingu
+cbnj=cburnrub~=cburnrub2
+cbuster=cbusterj=cbusterw=twocrude
+ccastles1~=ccastles2~=(ccastles3=ccastlesf=ccastlesg=ccastlesj=ccastlesp=ccastles)
+ccboot=ccboot2=cclimber=cclimberj
+cchasm=cchasm1
+cclimbr2=cclimbr2a
+cdiscon1~=csweetht
+cgangpzlj=cgangpzl
+cgraplop=cgraplop2
+cham24~=multigm2~=multigm3~=multigam=multigmb~=multigmt
+champbb2a=champbas=champbb2=champbasj=champbasja
+champwr=champwrj=champwru
+changes=changesa=looper
+chaoshea~chaosheaj
+chasehq=chasehqj=chasehqu
+checkmanj~checkman
+chelnov=chelnovj=chelnovu
+chikij=mtwins
+chinagat=saiyugoub1=saiyugoub2=saiyugou
+chinhero2=chinhero=chinherot
+chinmoku=iemoto=mjnanpaa=mjnanpas=mjnanpau=mladyhtr=seiha=seiham~=(orangec~=orangeci~=mmsikaku)~=vipclub~(iemotom=ryuuha~=ojousan~=ojousanm)~(club90s=club90sa)~ [lovehous also relationship unknown]
+choplift=chopliftu=chopliftbl
+chopper=choppera=chopperb=legofair
+chqflag=chqflagj
+chukatai=chukataij=chukataiu
+circus=circusse
+circusc=circusc2=circuscc=circusce~=circusc3
+citybombj=citybomb
+citycon=citycona=cruisin
+citylove=mcitylov
+clapapa=clapapa2
+clowns~clowns1
+clshroads=clshroad
+cltchitr=cltchitrj~=mvp=mvpj(balls=4 on MVP)
+cluedo=cluedo2c~=cluedo2
+cnightst2=cnightst
+cninja=cninja1=cninjabl=cninjau=joemac=stoneage
+cobracomj=cobracom
+colony7=colony7a
+colt=nycaptor
+columns=columnsj=columnsu~=(column2j=columns2)
+comg128~comg239
+commandob=commandoj=commando=commandou=sinvasn=sinvasnb
+compgolfo=compgolf
+congo=tiptop
+contcirc=contcircu~=contcircua
+contra=contra1=contrab=contraj=contrajb~=(gryzor=gryzora) (difference is lives - simultaneous players and alternate)
+cop01~cop01a
+cosmccop~gallop
+cosmica=cosmica1=cosmica2
+cosmogng=cosmogngj
+cotton=cottonj=cottonu
+cottong=gutangtn=locomotn
+countrunb=countrunb2=countrun
+countryc=fitegolfu=fitegolf
+couple=couplei=couplep
+cpoker=cpokert
+cppicf=cppicf2
+crash=smash
+crazycop=gbustersa=gbusters
+crbaloon2=crbaloon
+crgolf=crgolfa=crgolfb=crgolfbt=crgolfc~crgolfhi
+crimfght~=(crimfght2=crimfghtj)
+crkdown=crkdownj=crkdownu
+crmaze=crmazea=crmazeb (unchecked relationship)
+croquis=logicpro
+crshrace2=crshrace
+crush=crush2=crush3=crush4=crushbl=crushbl2=crushs=korosuke=maketrax=maketrxb=mbrush=paintrlr
+crusnusa21~crusnusa40~crusnusa~crusnwld13~crusnwld20~crusnwld23~crusnwld
+crystal2=crystalg~(mjdejavu=mjderngr=dondenmj~=(mcnpshnt=mjdiplob=royalmah=tontonb))~ttmahjng
+crzrallya=crzrallyg=crzrally
+csclub=csclub1=cscluba=csclubh=csclubj
+cscrtry~=cscrtry2
+csilver=csilverj
+csk227it~csk234it
+csprint=csprint1=csprint2~(csprints1=csprintf=csprints~=(csprintg1=csprintg))~(ssprintg1=ssprint=ssprint1=ssprint3~=(ssprintf=ssprintg=ssprints))
+cstlevna~=pc_cvnia
+ctisland~(ctisland2=ctisland3)
+ctribeb2=ctribe=ctribe1=ctribeb=ctribej
+cubeqst=cubeqsta
+cuebrickj~cuebrick
+cupfinal=hthero93~=(hthero94=intcup94)~=scfinals
+cupsoc=cupsoca=cupsocs=cupsocs2=cupsocsb=goal92=olysoc92
+cyberbal2p=cyberbal2p1=cyberbal2p2=cyberbal2p3~(cyberbal2=cyberbal=cyberbalp)~cyberbalt=cyberbalt1
+cybots=cybotsj=cybotsu
+cybsled=cybsledj
+dadandrn=mmaulers
+daimakai~=(daimakair=ghouls=ghoulsu)
+dairesya=farwest=ironhors
+daisenpu~=(twinhawk=twinhawku)
+daiyogen=fromance=mfunclub=mjnatsu=natsuiro=nmsengen=idolmj~=nekkyoku
+dambustruk=dambustra=dambustr
+dangar~=(dangar2=dangarb)
+darius2~(darius2d=darius2do)
+dariusg=dariusgj=dariusgu~=dariusgx
+darius~dariuse~(dariusj=dariuso)
+darkadv~=devilw=majuu (the weapon cheats for darkadv are completely different!)
+darkedge=darkedgej
+darkseal1=darksealj=darkseal=gatedoom1=gatedoom
+darkseal2=wizdfire=wizdfireu
+dassault4=dassault=thndzone
+daytona=daytonam=daytonas=daytonat~daytona93
+dblaxle=pwheelsj
+dbldyn=dbldynf~(dynduke=dyndukef) (these are a LOT different!)
+dblplay~=strkzone~wseries
+dblpointd=dblpoint
+dbreed~dbreedm72
+dcclub=dcclubfd=dcclubj
+dday=ddayc
+ddayjlc=ddayjlca
+ddcrew~=(ddcrew1=ddcrewu)~=(ddcrew2=ddcrewj)
+ddenlovrb=ddenlovr~ddenlovj
+ddonpach=ddonpachj
+ddragon2u=ddragon2~=(ddragonba=ddragonw1=ddragonb2=ddragon=ddragonb=ddragonu=ddragonw=ddragonua=ddragonub) {Invincibility for 2 only}
+ddragon3b=ddragon3j=ddragon3p=ddragon3
+ddream95~(hoops95=hoops96)
+ddsom=ddsoma=ddsomb=ddsomh=ddsomj=ddsomjr1=ddsomr1=ddsomr2=ddsomr3=ddsomu=ddsomur1
+ddtod=ddtoda=ddtodh=ddtodhr1=ddtodhr2=ddtodj=ddtodjr1=ddtodjr2=ddtodr1=ddtodu=ddtodur1
+ddungeone=ddungeon=stoffy=toffy
+ddux=ddux1=dduxbl  (unchecked relationships)
+deadang~ghunter~leadang
+deadconxj=deadconx
+deathbrd=mutantf=mutantf3=mutantf4
+deerhunta=deerhuntb=deerhunt~=deerhuntc
+defcmnd=startrkd=tornado1=(zero~=zero2)~=(mayday=maydaya=maydayb)~=defence~=defender~=(defenderb=defenderg=defenderw)
+defense=sdi=sdib
+deltrace=omegrace
+demoderb~=demoderm
+demonwld1=demonwld2=demonwld3=demonwld4=demonwld
+depthch=depthcho=subhunt
+desertbr=desertbrj
+desertgu=roadrunm
+desterth=grescue=lrescue=lrescuem=mlander
+devilfsg=devilfsh
+devstors2=garuka~=(devstors3=devstors)
+devzone=devzone2
+dfeveron=feversos
+dharma=dharmak
+diehard=dnmtdeka (note: most cheats change the program code, for which there is an 8 byte offset)
+dietgo=dietgoe=dietgoj=dietgou
+digdug2=digdug2o
+digdug=digdugat1=digdugat=digdug1=digsid=dzigzag
+dimahoo=dimahoou-dimahoud=gmahou
+dingo~dingoe
+dino=dinohunt=dinoj=dinou=dinopic=dinopic2 {dinopic & dinopic2 untested not working)
+dinorex=dinorexj=dinorexu
+disco=discof
+djboy=djboya=djboyj
+dkgensan=hharryu~(dkgensanm72=hharry)
+dkong3=dkong3b=dkong3j
+dkongjnrj=dkongjr=dkongjrb=dkongjre=dkongjrj=dkongjrm=jrking~(mouser=mouserc)
+dmnfrnta=dmnfrnt
+doa~doaa  (unchecked relationship)
+docastle2=docastle=docastleo=douni~dowild~=jjack
+dockman=porter=portman
+dogfgt=dogfgtj
+dogosokb=dogosoke~(ikari=ikarijp=ikarijpb=ikarinc)=victroad
+dokyusei~dokyusp
+dominob=dominobv2
+dondokodj=dondokodu=dondokod
+donpachi=donpachihk=donpachij=donpachikr
+dorodon=dorodon2~=(ladybgb2=ladybug=ladybugb~ladybugg)  {ladybugg still has cheats to translate from other clones}
+dorunrun2=dorunrun=spiero~dorunrunca=dorunrunc
+dotron=dotrona=dotrone
+downtown2=downtown=downtownp
+dplay=einning
+dragoona=dragoonj
+drakton=drktnjr
+drgnbowl=gaiden=mastninj=ryukendna=ryukendn=shadoww=shadowwa
+drgnwrldv10c=drgnwrldv11h=drgnwrldv21=drgnwrldv21j=drgnwrldv20j=drgnwrld=drgnwrldv30
+drgpunch~=maya~sprtmtch
+drgw2~drgw2c~drgw2j
+dribling=driblingo
+driftout=driveout
+drivfrcb=drivfrcg~drivfrcp
+drmario~=pc_drmro
+drtoppel=drtoppelj=drtoppelu
+dsaber=dsaberj
+dsoccr94j~=dsoccr94
+dspirit=dspirita=dspirito
+dstlk=dstlka=dstlkh=dstlku=dstlkur1=vampj=vampja=vampjr1
+dualaslt=liberateb=liberate
+duckhunt~=pc_duckh
+dungeonmu=dungeonm=lightbr=lightbrj
+dunkmnia=dunkmniaj
+dyger=dygera
+dynamcop~=dyndeka2~dynamcopb~dynamcopc (dyndeka2, dynamcopb & dynamcopc not working)
+dynwar=dynwarj=dynwaru
+eagle=eagle2=eagle3=fantazia=mooncrs2=mooncrs3=mooncrsto=mooncrsb=mooncrstg=mooncrst=mooncrstu-mooncrstuk=smooncrs=spcdrag=spcdraga=spctbird~mooncrgx
+ecofghtra=ecofghtrh=ecofghtr=ecofghtru1=uecology~=ecofghtru(inf credits difference only)
+edf=edfbl=edfu
+edrandy=edrandy2=edrandy1=edrandyj
+eggor=eyes=eyes2=eyeszac
+eggs=rockduck=scregg
+eggventr7=eggventr8=eggventra=eggventr=eggventrd
+ehrgeiz=ehrgeiza=ehrgeizj
+elecyoyo2=elecyoyo
+elevatorb=elevator
+elim2=elim2a~elim2c~(elim4=elim4p)
+elvact2u=elvactr=elvactrj
+emeralda=emeraldaj=emeraldaja
+empcity=empcityj=empcityu=stfight=stfighta
+endurob2=endurobl=enduror=enduror1
+enigma2~enigma2a=enigma2b
+eprom=eprom2
+equites=equitess
+esckids~=esckidsj
+espial=espialu
+esprade=espradej=espradejo
+eswat=eswatbl=eswatj=eswatu
+euro2k2=euro2k2a {untested neither work}
+euroch92~=(footchmp=hthero)
+evilngt=hellngt {untested neither working}
+excitebkj=excitebk
+excthour=matmania~(maniach=maniach2) (maniach/maniach2 are also missing sound test cheats)
+exctleag~=suprleag
+exctscc2=exctsccra=exctsccrb=exctsccrj=exctsccrj2=exctsccr
+exedexes=savgbees
+exerion=exerionb=exeriont
+exerizer=exerizerb
+exerizrb=skyfox
+exodus=galap1=galap4=galapx=galaxbsf=galaxiana=galaxian=galaxianm=galaxianmo=galaxiant=galturbo=gteikob2=gteikokb=gteikoku=kamakazi3=moonaln=redufo=redufob=skyraidr=spacbat2=spacbatt=spacempr=starfght=superg=uniwars=zerotime~=supergx=swarm~(moonal2=moonal2b)~=gmgalax  {may be differences in the credits poke value across all the games)
+exprraida=exprraid=wexpressb=wexpressb2=wexpress
+extrmatnj=extrmatn
+exzisus=exzisusa
+f15se=f15se21 {unchecked relationship as f15se non-working}
+f1dream=f1dreamb
+f1gp=f1gpb
+fa=fghtatck
+fantasia=fantsy95=newfant=supmodel=galsnewa=galsnewj=galsnewk~=galsnew~(missmw96=missw96)~(fantsia2=fantsia2a=wownfant)
+fantasy=fantasyu=fantasyj (no relation to spectar!)
+fantjour=fantjoura~gokuparo~sexyparo
+fantland~fantlanda
+fantzone=fantzone1=fantzonep
+farmer=ikki
+fatfursa=fatfursp
+fax=fax2
+fcrash=ffight=ffightj=ffightj1=ffightj2=ffightu=ffightua=ffightub~=ffightjh (ffightjh has infinite supers - not applicable to the other versions)
+ffantasy=ffantasya=ffantasybl=hippodrm
+fghthist=fghthista=fghthistj=fghthistu
+fgoal=fgoala
+fhawk=fhawkj
+fieldday=undoukai
+fightfev=fightfeva
+fightrol=rollace=rollace2
+finalap2=finalap3=finalap3a=finalap3j=finallapc=finallapd=finallap=finalap2j==finallapjb=finallapjc
+finalaprj=finalapr=finalapro     (unchecked relationship)
+finalb=finalbj=finalbu
+finalizrb=finalizr
+findout=reelfun=reelfun1
+firefox=firefoxa
+firehawk=spec2k~=(redhawk=redhawkb=redhawke=redhawki)~(grdnstrm=grdnstrmk~=stagger1)  {replicate grdnstrm quick beam cheat)
+fireshrk~=samesame2~samesame
+firetrap=firetrapbl=firetrapj (firetrapj untested - as not working)
+fitter=roundup~=fitterbl (fitterbl uses a time countdown)
+fixeightb=fixeight
+fjbuster=shogwarr=shogwarre
+flamegunj=flamegun
+flashgal=flashgala
+flickys1=flickys2=flicky=flickyo
+flipull=plottinga=plottingb=plottingu=plotting
+flkatck=mx5000
+flower=flowerj
+flstory=flstoryJ
+foodf=foodf2=foodfc
+forgottn=forgottnu=forgottnua=lostwrld=lostwrldo (forgottn untested)
+fort2b~fort2ba
+fpoint=fpoint1=fpointbj=fpointbl
+freekickb2=freekickb=freekick
+friskyt~=friskyta
+frogf=frogger=froggermc=froggers1=froggers2~(froggers=frogg)
+fround=froundl=hpuncher
+fshark=fsharkbt=hishouza=skyshark
+fsoccer=fsoccerb=fsoccerj
+fstarfrc=fstarfrcj
+fswords=samsho3=samsho3h
+ftimpact=ftimpcta (ftimpact not working so untested)
+fullthrl=topspeedu=topspeed
+funkybeeb=funkybee~=(skylancre=skylancr)
+funkyjetj=funkyjet
+funnymou=machomou=suprmous
+funybublc=funybubl
+funystrp~puckpepl
+futflash=laserbas=laserbasa  (unchecked relationship)
+fx=srdmissn
+g13knd~golgo13
+ga2=ga2j=ga2u
+gaiapolsj=gaiapols=gaiapolsu
+gaia~=theroes (Invincibility difference & Enable Secret Chars for gaia and selection & weapon use cheats for theroes)
+gal10ren~=jituroku
+galaga3=galaga3a=galaga3m=gaplus=gaplusa=gapluso
+galaga88j=galaga88
+galaga=galagamf=galagamk=galagamw=galagao=gallag=gatsbee
+galivan=galivan2
+galpani2g=galpani2t~galpani2~galpani2j
+galpani4~galpani4k (offset for k = +4)
+galpanica~galpanic
+galpanis=galpanisk
+galpans2=galpans2a=galpans3=galpansu=panicstr
+galspnbl~hotpinbl
+galxwars2=galxwars=galxwarst=starw
+gangonta=prtytime
+gangwarsb=gangwars
+gardia~gardiab
+garou=garoubl=garouo=garoup
+gaunt22p1=gaunt22pg=gaunt22p~=(gaunt2=gaunt2g) {difference is that 2 player versions don't need the yellow and green cheats)
+gauntdl~gauntdl24
+gauntleg12~gauntleg
+gauntlet2pg1=gauntlet2pj2=gauntlet2pr3=gauntlet2p=gauntlet2pg=gauntlet2pj~=(gauntletg=gauntletj=gauntletj12=gauntlet=gauntlets)~(gauntletgr3=gauntletgr6=gauntletgr8=gauntletr1=gauntletr2=gauntletr4=gauntletr5=gauntletr7=gauntletr9)
+gberet=gberetb=rushatck
+gblchmp=kaiserknj=kaiserkn
+gensitou=prehisle=prehisleu
+geostorm=gunforc2
+gepoker=gepoker1=gepoker2 (unchecked relationship)
+getstar~(getstarj=gtstarb1=gtstarb2=gtstarb)
+gforce2=gforce2j=gforce2ja
+ggreats2=opengolf2=opengolf
+gground~=ggroundj (ggroundj has a single credit cheat and no PL3)
+ghostb~=ghostb3~=meikyuh=meikyuha
+ghox=ghoxj
+gigandes~=gigandesj (credits only the same other offset by 8)
+gigasb=oigas~gigasm2b
+gigawing=gigawinga=gigawingb=gigawingh=gigawingj=gwingjd
+gijoe=gijoej=gijoeu
+ginganina=ginganin
+gionbana~=maiko
+gladiatr=greatgur=ogonsiro
+glass=glass10=glassbrk  (unchecked relationship)
+glfgreat=glfgreatj
+gmgalax~=(pacmanbl=pacmanbla~(abscam~=ctrpllrp=hangly=hangly2=hangly3=joyman=newpuc2=newpuc2b=newpuckx=pacheart=pacman=pacmanf=pacmod=popeyeman=puckman=puckmana=puckmanf=puckmanh=puckmod~=(jrpacman~jrpacmbl)~=(mspacmab=mspacman=mspacmat=mspacmbe=mspacmnf=mspacpls=pacgal)~=pacplus~=(piranha=piranhah=piranhao)~=mschamp=mschamps))~=alibaba~=(nmouse=nmouseb)
+gng=gnga=gngbl=gngblita=gngt=makaimurc=makaimurg=makaimur
+gobyrc=rcdego (unchecked relationship)
+gogold=recordbr
+gogomile~=gogomilej
+goindol=goindolk=goindolu=homo
+goldmedla=goldmedlb=goldmedl
+goldnaxeb1=goldnaxeb2=goldnaxe1=goldnaxe2=goldnaxe3=goldnaxe=goldnaxej=goldnaxeu  (goldnaxeb1 & goldnaxeb2 untested - game not working)
+goldnpkb=goldnpkr=jokerpkr=potnpkra=pottnpkr=pmpoker {unchecked relationship}
+goldstar=goldstbl=moonlght
+gondo=makyosen
+goodejana=goodejan
+goonies~=pc_goons
+gorf~=gorfpgm1=gorfpgm1g
+gorkans=mrtnt
+gotcha=ppchamp
+gpilots=gpilotsh
+gprider1=gprider1  (unchecked relationship)
+gradius2=gradius2a=gradius2b=vulcan=vulcana=vulcanb
+gradius3=gradius3a=gradius3e
+gradius~nemesis=nemesisuk
+gratia=gratiaa
+gravitar=gravitar2=gravp~(lunarba1~=lunarbat)
+grindstma~=grindstm~vfive (a lot of differences!)
+grobda=grobda2=grobda3
+growl=growlu=runark
+gs4002=gs4002a (unchecked relationship)
+gseeker=gseekerj=gseekeru
+gslgr94j~gslgr94u~gslugrsj
+gstrik2=gstrik2j
+gstriker=gstrikera
+gsword=gsword2
+gt2k=gt2kp100=gt2ks100=gtclassc=gtclasscp=gtclasscs~gt2kt500~gt3d~(gt3dl191=gt3dl192)~gt3ds192~gt3dt211~gt3dt231~gt3dv14~gt3dv15~(gt3dv16=gt3dv17=gt3dv18)~(gt97=gt97v122=gt98=gt98s100=gt98v100)~(gt97s121=gt97v120=gt97v121)~gt97t240~gt97t243~gt98t303~(gt99=gt99s100)~gt99t400~gtroyal~gtsuprem
+gtg~=(gtg2=gtg2t)~=gtg2j~=gtgt
+gticlub=gticlubj  (unchecked relationship)
+gtmr2=gtmr2u~gtmr2a
+gtmr=gtmra~(gtmre=gtmrusa)
+gtsers1=gtsers2~=(gtsers3=gtsers4=gtsers5=gtsers7=gtsersa=gtsersb=sextriv1=sextriv2)~=(gtsers9=gt103a1=gt103a2=gt103a3=gtsers10=gt103aa=gtsers11=gt103asx)~gtsers8~gt5~=sprtauth~gt507uk
+gulfstrmm~=gulfstrm
+gulfwar2=ktiger=twincobr=twincobru
+gumbo=mspuzzleg
+gunball~=nitrobal (select stage cheats differ slightly)
+gunbird=gunbirdj=gunbirdk
+gunbuletj=gunbuletw~=ptblank (only difference - credits differently triggered)
+gundealra=gundealr=gundealrt
+gundl94=primella
+gunforce=gunforcej=gunforceu
+gunfront=gunfrontj
+gunhohki=mysticri=mysticrib
+gunlock=rayforce=rayforcej
+gunsmokeua=gunsmoke=gunsmokej=gunsmokeu
+gussun~=riskchal
+gwar=gwara=gwarb=gwarj
+gyruss=gyrussce=venus
+hal21=hal21j
+halleycj=halleys=halleysc~=halley87
+hanamai~hnkochou
+hangon=hangon1=shangonle=shangon=shangon1=shangon2=shangon3!shangonrb
+harddrivb5~=(harddrivb6=harddrivb)~=(harddrivg4=harddrivg)~=(harddriv=harddriv2=harddriv3)~=harddriv1~(harddrivc1~=(harddrivcb=harddrivc)~=harddrivcg)~(harddrivj6=harddrivj)~~strtdriv (= in this instance include identical ROM cheats)
+harddunkj=harddunk
+hardhead=hardheadb=pop_hh
+hardyard=hardyard10
+hatris=hatrisj
+hbarrel=hbarrelw
+hcastle=hcastleo=hcastlej=hcastljo
+heatbrl=heatbrl2=heatbrlo=heatbrlu
+hedpanic~=hedpanicf~=hedpanico (hedpanico shares credits only - hedpanicf has more cheats to be duplicated (should be simple copy for hedpanic))
+helifirea=helifire
+hellfire1~=hellfire3~hellfire2=hellfire
+herbiedk~hncholms~huncholy
+hero~(herodk=herodku)~(outline=radarzon1=radarzont=radarzon) {the hero and radarzone games are completely different)
+hexpool=hexpoola=racknrol
+hiimpact1=hiimpact2=hiimpact3=hiimpact4=hiimpact~hiimpactp
+hiryuken=shangkid
+hitice=hiticej
+hitme=m21
+hitnmiss2=hitnmiss
+hnayayoi=hnfubuki
+hoccer~hoccer2
+hogalley~=pc_hgaly
+hook=hookj=hooku
+hopprobo~springer
+hotgm4ev~=hotgmck~=hotgmck3~=hotgmcki
+hotmemry~(pairs=pairsa)
+hotrod=hotroda~=hotrodj (PL4 differences)
+hotshock=hotshockb
+hourouki=mhgaiden~(mjclinic=mjhokite=mrokumei)
+housemn2=housemnq~livegal
+hpolym84=hyperspt=hypersptb
+hsf2=hsf2a=hsf2d=hsf2j
+hstennis10~=hstennis
+hthero95=hthero95u=pwrgoal
+hunchbak=hunchbaka~hunchbkd~hunchbkg~=hunchbks
+hvysmsh=hvysmsha=hvysmshj {unchecked relationship}
+hvyunit=hvyunitj=hvyunito {unchecked relationship - none work}
+hwchamp=hwchampj
+hydra=hydrap2~=hydrap
+hyperbbck=hyperbbc (untested relationship)
+hyperpac=hyperpacb
+hyperpac~hyperpacb
+hyprduel2=hyprduel
+iceclimb=iceclimbj~=iceclmrj
+ichir=ichirj=ichirjbl=ichirk~=(tantr=tantrbl=tantrbl2=tantrbl3=tantrkor)
+iganinju=kazan
+ikari3=ikari3nr
+imago=imagoa
+imgfighto=imgfight
+imsorry=imsorryj
+indytemp2=indytemp4=indytempd=indytemp~=indytemp3~indytempc (indytempc not working)
+insectx=insectxj
+inthunt=inthuntu=kaiteids
+intrepid2=intrepid=zaryavos
+intruder=laser=spcewarl=spclaser
+invrvngea=invrvnge
+iqblock=iqblocka=iqblockf (untested relationship)
+jack=jack2=jack3=treahunt
+jackal=jackalj=topgunbl=topgunr
+jackrabt2=jackrabts=jackrabt
+jailbrek=jailbrekb=manhatan
+janbari~mjanbari~=pachiten
+jchan~jchan2
+jdredd~jdreddb
+jgakuen=rvschoola=rvschool
+jjparad2~jjparads~ryouran
+jleague=svf=svs
+jogakuen~lemnangl~mjyougo
+jojoa=jojoan~(jojo=jojon)
+jojoba=jojoban=jojobane
+jolyccra=jolyccrb=jolycdab=jolycdat=jolycdit=jollycrd    (unchecked relationship)
+joust=joustr=joustwr~=joust2 (joust2 is very different but the at least lives are identical)
+joyfulr=mnchmobl
+jpopnics=plumppop
+jumpbug=jumpbugb
+jumping=rainbow=rainbowo~rainbowe
+jumpkids=jumppop~=pangpang~=(tumblep=tumbleb2=tumbleb=tumblepj)~fncywld(+ED8230 to address + other differences)
+jumpshot=jumpshotp
+jungleh=junglek=junglehbr=junglekj2~=piratpet
+jungler=junglers
+junofrst=junofrstg
+kabukiz=kabukizj
+kageki=kagekih~=kagekij (kagekij may have no differences - just need cheats replicating maybe?)
+kaguya~=(kaguya2=kaguya2f)~(otatidai=psailor2) (kaguya has character cheat)
+kakumei=~suchipi
+kamikcab=yellowcbb=yellowcbj
+kangarooa=kangaroob=kangaroo
+karatblzj=karatblzu=karatblz
+karatedo=karatevs=kchamp=kchampvs=kchampvs2
+karnov=karnovj
+kf10thep=kf2k5uni=kof10th~=(kf2k2mp=kf2k2mp2=kf2k2pla=kf2k2pls=kof2002=kof2002b~=kof2k4se(backdrop names) (All generally games added as straight clones of kof2002, all cheats haven't been confirmed beyond the basics - only difference spotted is the backdrops cheat)
+kf2k3bl=kf2k3bla=kf2k3pl=kf2k3upl=kof2003
+kicker=shaolinb=shaolins
+kicknrun=kicknrunu=mexico86
+kick~kickc~kickman
+kidniki=kidnikiu=lithero=yanchamr
+kikaioh=techromn=techromnu
+kikcubicb=kikcubic
+kikikai=knightb
+killbld=killbld104   (unchecked relationship as killbld104 doesn't work at all)
+kingballj=kingball
+kingdmgp=shippumd
+kingofb=ringking2=ringking3=ringking=ringkingw
+kinst2=kinst210=kinst211=kinst213=kinst2k3=kinst2k4  {2k3 and 2k4 don't work so untested}
+kinst=kinst13=kinst14~=kinstp(energy locations differ)
+kittenk=nyanpani
+klax~klax2=klax3=klaxd=klaxj~(klaxp1=klaxp2)
+knckhead=knckheadj
+knights=knightsj=knightsu
+kod=kodb=kodj=kodu
+kof2003=kof2003h
+kof95=kof95h
+kof96=kof96h
+kof97=kof97h=kof97pls=kog
+kof98=kof98k=kof98ka=kof98h
+kof99=kof99a=kof99e=kof99k=kof99p~=(kof2000=kof2000n)~=(ct2k3sa=ct2k3sp=cthd2003=kof2001=kof2001h)
+konam80a=konam80j=konam80k=konam80s=konam80u
+konamigt~rf2
+kotm=kotmh
+kov2~=kov2100=kov2102=kov2103=kov2106
+kov=kov115=kov100~kovplus
+kram=kram2=kram3
+ktiger2=tcobra2=tcobra2u
+kuhga=vaportra=vaportrau
+kungfub=kungfub2=kungfumd=kungfum=spartanx
+kungfut=kungfuta (Different Comment due to door codes being different (different objects behind doors), locations the same though)
+kuniokunb=kuniokun=renegade
+kurikinta~=(kurikintj=kurikint=kurikintu) [DIP SWITCH COMMENT + CREDIT DIFFERENCES]
+kyros=kyrosj
+kyukaidk=kyukaidko
+labyrunrk=labyrunr=tricktrp
+ladygolf=smgolf=smgolfb=smgolfj
+ladykill=moegonta
+lagirl=plgirls
+landbrk=landbrka
+lans2004=shocktr2
+lastblad=lastbladh=lastsold
+lastbrnxj=lastbrnx   (unchecked relationship)
+lastday=lastdaya
+lastduel=lastduelb=lastduelj=lastduelo
+lastforte=lastfortk=lastfort~lastfortg
+lastmiss=lastmisnj=lastmisno
+lazarian~=laserbat (most locations different & lazarian doesn't need rapid fire)
+lazercmd~minferno
+ldrun2=ldrun3=ldrun3j~ldrun4
+ldrun=ldruna
+le2=le2u~le2j  {le2j untested as bad dump}
+leaguemn=nbbatman
+ledstorm=ledstorm2=madgear=madgearj
+legion=legiono
+legionna=legionnau
+leprechn=leprechp=potogold~=piratetr
+lethalenj=lethalen=lethalenua=lethalenux=lethaleneab=lethaleneae
+lethalth=thndblst
+lghost=lghostu
+lgtnfghta=lgtnfght=lgtnfghtu=trigon
+lhb=lhbv33c (untested relationship)
+liberatr2~liberatr
+lifefrce=lifefrcej=salamand=salamandj
+liquidk=liquidku=mizubaku
+lkage=lkageb=lkageb2=lkageb3=lkageo=lkageoo
+lockload=lockloadu
+lockon=lockonc
+loderndfa~loderndf
+loffire=loffirej=loffireu
+loht=lohtj~(lohtb~lohtb2) (lohtb&lohtb2 non-working - reason1)
+lomakai=makaiden
+looping=loopingv=loopingva~=skybump
+losttombh=losttomb~=superbon
+lsasquad=storming
+lucky8=lucky8a=lucky8b~ns8linew
+luckywldj=luckywld
+lupin3=lupin3a
+luplup=luplup29=puzlbang=suplup     (unchecked relationship)
+lvgirl94=zerozone
+lwings=lwings2=lwingsb=lwingsj
+mace~macea
+madalien=madaliena
+madball=madballn
+madcrash=madcrush
+maddonna=maddonnb
+magic10=magic10a     (unchecked relationship)
+magicbuba~=magicbub (everything apart from credits are different locations)
+maglord~maglordh
+mahoudai=sstriker=sstrikera
+mainevt=mainevto=ringohja~=(mainevt2p)
+majest12~ssi
+majtitl2j=majtitl2=skingame2=skingame
+majtitle=majtitlej
+majxtal7~=tenkai=tenkai2b=tenkaibb=tenkaicb=tenkaid=tenkaie (unchecked relationship - many not working, majxtal7 cheats maybe able to be fully duplicated?)
+maniacsp~maniacsq
+mappy=mappyj
+marble=marble2=marble3=marble4=marble5
+mario=marioe=marioj=marioo=masao=pestplce
+martmast=martmastc~martmastc102
+marvland~=marvlandj (time difference)
+mastboy=mastboyi (unchecked relationship)
+masterw=masterwj=masterwu
+matchit2=shisen2
+matchit=shisen=sichuan2=sichuan2a
+mating=matingd   (unchecked relationship)
+matrim=matrimbl
+maxf_102=maxf_ng=maxforce
+maya=mayaa
+mayumi~=mjkjidai
+mazerbla=mazerblaa     (unchecked relationship)
+mazinger=mazingerj
+mbomberj=slammast~(mbombrd=mbombrdj)
+mchampdxa~=mchampdx
+mcombat=mcombata~(missile~=(suprmatkd=suprmatk))~missile2 {ROM relationship shown as all cheats currently ROM cheats}
+mechatt=mechattu
+megablst=megablstj=megablstu
+megaforc=starforca=starforcb=starforc=starforce
+megaman=rockmanj~=(megaman2=megaman2h=megaman2a=megamn2d=rockman2j)~=(mmancp2u=rmancp2j)
+megat3=megat3a=megat3ca=megat3nj=megat3te (unchecked relationship)
+megat4=megat4a=megat4sn=megat4st=megat4te
+megat5=megat5a=megat5nj (unchecked relationship)
+megazonei=megazonea=megazoneb=megazonec=megazone
+mercs=mercsj=mercsu=mercsua
+mermaid=yachtmn
+metalb=metalbj
+metamrph=metamrphu~=metamrphj
+meteor=spcforc2=spcforce
+metlhawk=metlhawkj
+metmqstr=nmaster
+metrocrsa=metrocrs
+mgcldate=mgcldtex   (mgcldate not working so untested)
+mgcrystlj~=mgcrystl~=mgcrystlo(no auto shot cheat)
+mia=mia2~miaj (same locations but different CPU)
+midres=midresb=midresj=midresu (midresb not checked - but should work)
+mikie=mikiehs=mikiej
+millipdd=milliped
+mimonkey=mimonsco~mimonscr
+minefld=rescue
+minigolf2=minigolf
+mjchuuka~=mjdchuka~=(mjifb=mjifb2=mjifb3)~=(mjmyornt=mjmyster=mjmyuniv=mjmywrld)~=mjreach=mjreach1  (winning hand the same)
+mjdejav2=mjdejavu
+mjelct3=mjelct3a=mjelctrb=mjelctrn~=mjfriday~=(mjelct3=mjelct3a=mjelctrn)~ojankoc
+mjkojink~=vitaminc
+mjnquestb=mjnquest
+mjyuugi=mjyuugia
+mk2=mk2r30=mk2r31e=mk2r14=mk2r21=mk2r32~=(mk2chal=mk2r42=mk2r91)
+mk3=mk3r20~mk3r10~(umk3=umk3r10=umk3r11)
+mk4~mk4a~mk4b
+mk=mktturbo=(mkla3=mkyawdim=mkyturbo)=mkla4=mkr4~=(mkla1=mkla2)~mkprot9 (mkyawdim & mkyturbo identical to mkla3 for ROM too apparently)
+mmatrix=mmatrixd=mmatrixj
+moguchan=zodiack
+moo=mooaa=moobl=mooua
+moonwar=moonwara
+moremore~=moremorp
+mosaic=mosaica
+motofrenwwallybrfat~(motofmd~=motofrenmf)
+motorace=travrusa
+mpang=mpangj=mpangr1=mpangu
+mpatrol=mpatrolw
+mplanetsuk~mplanets
+mp_gaxe2~=mt_gaxe2
+mp_sonic~=(mp_soni2~=mt_soni2)~=mt_sonia=mt_sonic
+mrdo=mrdofix=mrdot=mrlo=mrdu=yankeedo~mrdoy
+mrkougar=mrkougb=mrkougb2=mrkougar2
+mrviking=mrvikingj
+ms4plus=mslug4~=mslug4h (many weapony cheats are +4 in the h version)
+ms5pcb=ms5plus=mslug5=mslug5h
+msgundam1=msgundam
+msh=msha=mshb=mshh=mshj=mshjr1=mshu=mshud
+mshuttle=mshuttlej2=mshuttlej
+mshvsf=mshvsfa=mshvsfa1=mshvsfb=mshvsfb1=mshvsfh=mshvsfj=mshvsfj1=mshvsfj2=mshvsfu=mshvsfu1
+mslug3=mslug3b6=mslug3n
+mspuzzle=mspuzzlen   (mspuzzlen not working so untested)
+mstworld~=sbbros=spang=spangbl=spangj (differences are panic/tour levels - mstworld has no tour selection and levels are different)
+msword=mswordj=mswordr1=mswordu
+mtlchamp=mtlchamp1=mtlchampa=mtlchampj=mtlchampu
+mtrap=mtrap3=mtrap4
+multchmpk=multchmp
+murogem=murogema=murogmbl (unchecked relationship - reason06)
+mustang=mustangb=mustangb2=mustangs=twinactn
+mvsc=mvsca=mvscar1=mvscb=mvsch=mvscj=mvscjr1=mvscr1=mvscu=mvscud=mvscur1
+mwalk=mwalkbl=mwalkj=mwalku
+myhero=myherok=sscandal
+myqbert=qbertj~=sqbert
+myststono~=mystston (ROM indicates most locations are different)
+mystwarr=mystwarra=mystwarrj=mystwarru
+nametune~nametune2
+narc=narc2=narc3
+nastar=nastarw=rastsag2
+natodef=natodefa
+naughtyba=naughtyb=naughtybc
+nbahangt~nbamht=nbamht1
+nbajam~nbajamr2~(nbajamte=nbajamt1=nbajamt2=nbajamt3)
+ncombat=ncombath
+ncv1=ncv1j=ncv1j2 (ROM cheat differences don't count)
+nebulray=nebulrayj
+nemo=nemoj
+neocup98=ssideki3
+news=newsa
+newtangl=troangel
+nibbler=nibblera=nibblerb=nibblero
+nightstrj=nightstru=nightstr
+ninja=nprinces=nprincesb=nprinceso=nprincesu=seganinj=seganinju
+ninjak=ninjakj=ninjaku
+ninjakd2a=rdaction~(ninjakd2b=ninjakd2)~(ninjakun [THIS GAME MISSING CHEATS!])
+ninjaw=ninjawj
+ninjemak=youma=youma2=youmab=youmab2
+nitd=nitdbl
+nkdodge=nkdodgeb=spdodgeb
+nmg5=nmg5e
+nob=nobb
+nomnlnd~nomnlndg
+nost=nostj=nostk
+nova2001u=nova2001
+nrallyx=nrallyxb=rallyx=rallyxa=rallyxm
+nslasherj=nslasher=nslashers
+nspirit=nspiritj
+nstocker=nstocker2
+nwarr=nwarra=nwarrb=nwarrh=nwarru=nwarrud=vhuntj=vhuntjr1=vhuntjr2
+offroadc1~offroadc3~offroadc4
+offroadt2p=offroad=offroadt
+offtwallc~offtwall
+olds=olds100=olds100a
+omega=theend=theends
+omegaf=omegafs
+omni=pisces=piscesb
+onetwo=onetwoe
+onna34roa=onna34ro
+opwolf3=opwolf3u
+opwolf=opwolfa=opwolfb=opwolfu
+ordyne=ordynej
+orlegend105k=orlegend111c~(orlegend=orlegendc=orlegende)
+orunners=orunnersu
+oscar=oscarj2=oscarj0=oscarj1
+othunder=othunderj=othunderu=othunderuo
+outfxiesj=outfxies
+outrun=outrunb=outrundx=outruno=outrunra
+outzone~=(outzonea=outzonec=outzoned)~=outzoneb
+ozmawars=ozmawars2=solfight=spaceph
+p47=p47j
+pacland=paclandj=paclandjo=paclandjo2=paclandm
+pacmania~=pacmaniaj
+pacnchmp=pacnpal=pacnpal2
+paintlad=splash=splash10~=(roldfroga=roldfrog) {Select Girl cheat not in roldfrog}
+pairsnb=pairsten
+pang3=pang3j=pang3n
+pangpomsm=pangpoms
+panic=panic2=panic3=panicger=panich
+panzer=phantom=phantoma=rallys=spectar=spectar1~=(targ=targc)
+paperboy=paperboyr2~paperboyr1
+parodiusj=parodius
+passht4b=passsht=passshta=passshtb=passshtj=passsht16a (passht4b,passshta,passshtj, passsht16a should probably have different descriptions due to being 4p games)
+pbaction=pbaction2=pbaction3=pbaction4=pbaction5
+pbchmp95=witch    (unchecked relationship)
+pbillrd=pbillrds
+pbobble2j=pbobble2u=pbobble2o~=pbobble2~=pbobble2x~pbobbl2n
+pbobble3j=pbobble3u=pbobble3
+pbobble4j=pbobble4u=pbobble4
+pbobblen=pbobblenb
+pbobble~pbobblbs
+pcktgal=pcktgal2=pcktgalb=pcktgal2j=pokechmp=spool3=spool3i
+pclubys=pclubysa
+pc_grdue=pc_grdus=vsgradus
+pc_smb~=suprmrioa=suprmrio=suprmriobl==suprmriobl2=skatekds
+pdrift=pdrifta=pdrifte=pdriftj
+peggle~=pegglet
+pengo=pengo2=pengo2u==pengo3u=pengo4u=pengob=penta
+perestrof=perestro~=(sqix=sqixb1=sqixb2=sqixr1=sqixu)  {perestr* games don't need the letter cheat - although it's still in the code}
+perfrman=perfrmanu
+photof=wwjgtin
+pigout=pigouta
+pinbo==pinboa=pinbos
+pipedrm=pipedrmu~=pipedrmj (minor differences mainly 'Stop water from flowing' doesn't work for us version)
+pipibibi=pipibibs=pipibibsa~whoopee
+pitfall2=pitfall2a=pitfall2u
+pitfight3=pitfight4=pitfightb~=pitfight=pitfight6~=pitfightj~=pitfight7  (pitfight7 time = pitfightj time is only difference for pitfight to other clones)
+pitnrun=pitnruna
+pkladies=pkladiesbl=pkladiesl=pkladiesla
+pktgaldxb=pktgaldxj=pktgaldx
+pkunwar=pkunwarj
+plegendsj=plegends
+plsmaswd=plsmaswda=stargld2
+pltkids=pltkidsa
+polepos=polepos1=polepos2=poleposa=polepos2a=polepos2b=polepos2bi=topracer=topracera=topracern
+policetr13b=policetr11=policetr~=policetr10
+pollux=polluxa=polluxa2
+ponchin=ponchina
+ponpoko=ponpokov
+pootan=pooyan=pooyans
+popeye=popeyef=popeyeu~popeyebl
+popflamea=popflameb=popflame
+popnpop=popnpopj=popnpopu
+portrait=portraita
+poundforj=poundfor=poundforu
+pow=powj
+powerbal~powerbals
+powerinsa=powerinsb=powerinsj=powerins
+primrage~primrage20
+prmrsocrj=prmrsocr
+prmtmfgto=prmtmfgt=trstar=trstarj=trstaro=trstaroj
+progear=progeara=progearj=progerjd
+progolf=progolfa {unchecked relationship - neither works}
+promutrva=promutrvb=promutrv    (unchecked relationship)
+psoldier~=ssoldier (character names differ)
+pspikes=pspikesb=pspikesc=pspikesk=spikes91~svolly91
+psychic5=psychic5a
+psychos=psychosj
+psyforce=psyforcej~psyforcex
+ptblank2~ptblnk2a (sound test timer is the same location though)
+puchicar=puchicarj
+pulirula=pulirulaj
+punchita=punchout=spnchout=spnchoutj
+punipic=punipic2=punipic3=punisher=punisherbz=punisherj=punisheru {punipic,punipic2,punipic3 untested not working}
+punkshot=punkshot2~=punkshotj
+pushman=pushmana=pushmans=pushmant
+puyo=puyoja=puyobl=puyoj~puyopuy2
+puzzldpr=puzzledp
+puzzloop~puzzloopj~(puzzloopk=puzzloopu)
+puzznic=puzznici=puzznicj
+pwrinst2j=pwrinst2
+pyros=wardner=wardnerj
+pzloop2=pzloop2j (pzloop2 untested)
+qbert=qberta=qberttst
+qix=qixo=qixb~=qix2
+qntoond=qntoondo    (unchecked relationship)
+qos=qosa=qosb
+quantum=quantum1=quantump
+quarterb=quarterba
+quartet=quarteta~=(quartet2=quartet2a) (Credit and Rapid Fire cheats are different only no real PL1-4 in 2 player version but comment covers)
+quiz365~quiz365t
+quizchql=quizchq
+quizdais=quizdaisk
+quizkof=quizkofk
+quizo=quizoa {untested no cheats}
+rabiolep=rpunch
+racedrivcb4=racedrivcg4=racedrivc4~(racedrivb1=racedrivg1=racedriv1=racedriv2=racedriv3)~(racedrivb4=racedrivg4=racedriv4)~(racedrivc1=racedrivc2)~(racedrivcb=racedrivcg=racedrivc)~(racedriv=racedrivb=racedrivg)
+racinfrc=racinfrcu
+racingj=racingj2   (unchecked relationship)
+rackemup~thehustlj=thehustl
+radarscp1=radarscp
+radm=radmu=radr=radru
+raiden2=raiden2a=raiden2b=raiden2c=raiden2d~(raiden2e=raiden2f)
+raiden~raidena=raidenk=raident~raidenu
+raiders5=raiders5t
+raidndx=raidndxa1=raidndxa2=raidndxg=raidndxj     (unchecked relationship)
+raiga=stratof
+raimaisjo=raimais=raimaisj
+rambo3~=(rambo3a=rambo3ae)
+rampage=rampage2
+rampart~rampartj~rampart2p
+rapidfir~=rapidfire (credits same, others ofset by 0x20)
+rastan=rastanu=rastanu2=rastsaga1=rastsaga
+raveracj=raveracw=raveracja
+raystormj~raystorm
+rbff1=rbff1a
+rbff2=rbff2h=rbff2k
+rbffspec=rbffspeck
+rbibb=rbibba
+rbtapper=sutapper=tapper=tappera
+rchase=rchasej
+rdft2=rdft2a=rdft2a2=rdft2j=rdft2j2=rdft2t=rdft2u~=rdft22kc~=rdft2us (minor differences)
+rdft~=(rdfta=rdftau=rdftdi=rdftit=rdftj=rdftu)  (rdft needs the unlock char & character cheats)
+realbrk=realbrkj=realbrkk
+redclash=redclashk=redclasha
+redearth=redeartn=warzard
+regulus=reguluso=regulusu
+relief~relief2
+rescraid=rescraida
+retofinv1=retofinv2=retofinv
+rezon=rezont
+rfjet=rfjet2kc=rfjeta=rfjetj=rfjetu=rfjetus
+ridgera2j=ridgera2ja=ridgera2    (unchecked relationship)
+ridgerac3=ridgeracb=ridgerac=ridgeracj~=rrf
+ridhero=ridheroh
+ridingfj=ridingfu=ridingf
+rimrockn=rimrockn20~(rimrockn12~=rimrockn16)
+ringdest=ringdstd=smbomb=smbombr1
+ringfgt=ringfgt2=vsgongf
+ringrage=ringragej=ringrageu
+rmhaihia=rmhaihib=rmhaijin=rmhaisei=themj
+rmpgwt=rmpgwt11
+roadblstc1=roadblstcg=roadblstg1=roadblstg2=roadblst1=roadblst2=roadblst3=roadblstc=roadblstg=roadblst
+roadf=roadf2
+roadrunn1~=roadrunn2~=roadrunn
+robocop2=robocop2j=robocop2u
+robokidj2=robokidj~=robokid
+robotron=robotronyo
+robowres=robowresb
+rockn=rockna
+rockragea=rockrage=rockragej
+rocnrope=rocnropek
+rodland~(rodlandj=rodlandjb)
+rohga=rohgah=rohgau=wolffang~=(rohga1=rohga2) (Rapid Fire and Select Mission addresses different)
+rollerg=rollergj
+rompers=romperso
+rongrongg=rongrongj=rongrong
+route16=route16a=route16b=routex
+royalcdb=royalcrd     (unchecked relationship)
+rpatrolb=rpatrolo~silvland
+rrreveng=rrrevenga=rrrevengb
+rthun2=rthun2j
+rthunder=rthundero
+rtriv~striv
+rtype2=rtype2j=rtype2jc
+rtype=rtypeb=rtypej=rtypeu=rtypejp
+rtypeleoj=rtypeleo
+rugrats=wiping
+rundeep~=thedeep
+rungun=runguna=rungunu=rungunua=slmdunkj
+rushcrsh=srumbler=srumbler2
+rygar=rygar2=rygar3=rygarj
+s1945=s1945a=s1945bl=s1945j=s1945k=s1945jn
+safari=safaria
+sailormn=sailormnh=sailormnj=sailormnk=sailormno=sailormnoh=sailormnoj=sailormnok=sailormnot=sailormnou=sailormnt=sailormnu
+sailorwa=sailorws
+salamand=salamandj
+salmndr2a=salmndr2
+samsho2=samsho2k
+samsho4=samsho4k
+samsho5=samsho5b=samsho5h~=(samsh5sp=samsh5sph=samsh5spn) {character name differences, still to be corrected though}
+samsho=samshoh
+samuraia=sngkace
+sandor~=(thunt=thuntk)
+sandscrpa=sandscrpb=sandscrp
+sanjeon=sasissu (unchecked relationship)
+sarukani=vblokbrk
+satansat=zarzon
+sb2003=sb2003a
+sbasketb=sbaskete=sbasketh=sbasketg
+sbdk~superbik
+sbishi~=sbishik (sbishik has 3 players)
+sbrkout=sbrkout3
+sbugger~sbuggera (sbugger not working so no ROM invincibility yet)
+schaser=schasercv
+sci=scia=scij=scin=sciu
+scion=scionc
+scontra=scontraj
+scross=scrossu
+scud~scuda~scudp    (unchecked relationship - make machine single/standalone to play)
+searchar=searcharj=searcharu
+searchey~searchp2
+secretab=secretag=slyspy=slyspy2
+sectionza=sectionz
+sectrzon=seicross
+sengekisj~sengekis
+sengokh=sengoku
+sextriv=statriv2=statriv2v=trivquiz~supertr2 (statriv2v unchecked)
+sexygal=sweetgal (unchecked relationship)
+sf2049~sf2049se~sf2049te     (unchecked relationship)
+sf2=sf2eb=sf2ebbl=sf2j=sf2ja=sf2jc=sf2qp1=sf2thndr=sf2ua=sf2ub=sf2ud=sf2ue=sf2uf=sf2ui=sf2uk~(sf2acc=sf2accp2=sf2ce=sf2cej=sf2ceua=sf2ceub=sf2ceuc=sf2dkot2=sf2koryu=sf2m1=sf2m2=sf2m3=sf2m4=sf2m5=sf2m6=sf2m7=sf2mdt=sf2rb=sf2rb2=sf2rb3=sf2red=sf2v004=sf2yyc~=(sf2hf=sf2hfj=sf2hfu)) [exact sf2 cheats missing some cheats from sf2ce -investigate please somebody(I hate this game)]
+sf=sfj=sfu=sfua~=sfp
+sfa2=sfa2u=sfz2a=sfz2ad=sfz2b=sfz2br1=sfz2h=sfz2n=sfz2j~=(sfz2al=sfz2ald=sfz2alb=sfz2alh=sfz2alj)~=(sfa3=sfa3b=sfa3h=sfa3u=sfa3ud=sfa3ur1=sfz3a=sfz3ar1=sfz3j=sfz3jr1=sfz3jr2)~=(vsav=vsava=vsavd=vsavh=vsavj=vsavu~=vsav2~=(vhunt2=vhunt2r1))~(pfghtj=sgemf=sgemfa=sgemfd=sgemfh)
+sfa=sfad=sfar1=sfar2=sfau=sfza=sfzch=sfzb=sfzbr1=sfzh=sfzhr1=sfzj=sfzjr1=sfzjr2
+sfex2=sfex2a=sfex2h=sfex2j
+sfex2p=sfex2pa=sfex2pj
+sfex=sfexa=sfexj=sfexu
+sfexp=sfexpj=sfexpu1
+sfiii2=sfiii2j=sfiii2n
+sfiii3=sfiii3a=sfiii3an=sfiii3n
+sfiii=sfiiij=sfiiin
+sfkick=sfkicka=spinkick (unchecked relationship)
+sformula=tail2nos
+sftm=sftm110=sftm111=sftmj
+sfx=skelagon
+sgmast=sgmastc=sgmastj   (sgmast not working so untested)
+sgunner2=sgunner2j
+sgunner=sgunnerj
+shadfrce=shadfrcejv2~=shadfrcej (credits same)
+shadowld=youkaidko=youkaidk
+sharkpy=sharkpya {untested neither work}
+sharrier=sharrier1
+shdancbl=shdancer=shdancer1=shdancerj
+shimpact=shimpactp4=shimpactp5=shimpactp6
+shinobi=shinobi1=shinobi2=shinobi3=shinobi4=shinobi5=shinoblb=shinobld=shinobls
+shiryu2=strider2=strider2a
+shocktra=shocktro
+shollow=shollow2
+shootoutb=shootoutj~shootout
+shougi=shougi2
+showhanc=showhand (unchecked relationship)
+shtngmst=shtngmste
+shtrider=shtridera
+shufshot=shufshot139~=shufshot137
+shuuz=shuuz2
+sia2650=tinv2650
+sidearmsj=sidearmsr=sidearms~=twinfalc=whizz
+sidepckt=sidepcktb=sidepcktj
+sidewndr~=spellbnd (reels are very different)
+silentd=silentdj=silentdu
+silkworm=silkworm2
+simpsons2pa=simpsons2p2=simpsons2pj=simpsons2p=simpsons4pa=simpsons
+sinistar1=sinistar2=sinistar
+sjryuko=sjryuko1
+skullfng=skullfngj
+skullxbo1=skullxbo2=skullxbo3=skullxbo4=skullxbo
+skykid=skykidd=skykido=skykids~=skykiddxo=skykiddx
+slikshot16=slikshot17~slikshot
+slipstrmh=slipstrm
+slither=slithera
+sltblgp1=sltblgpo    (unchecked relationship)
+smashtv=smashtv4=smashtv5=smashtv6~=smashtv3 (smashtv3 currently just has inf lives)
+smgp=smgp5=smgp6=smgpj=smgpja=smgpu=smgpu1=smgpu2=smgpu3
+smoto16=smoto20 {untested neither work}
+snowboara~snowboar
+snowbros3~=(snowbrosa=snowbrosb=snowbrosc=snowbrosd=snowbrosj=snowbros=wintbob) differences due to graphics ie. SNOW or BALL
+socbrawl=socbrawlh
+soccerssa=soccerssja=soccerss    (unchecked relationship)
+solarwar=xsleena=xsleenab
+soldam~soldamj
+solomon=solomonj
+sonic=sonicp
+sonson=sonsonj
+soulclbrj~soulclbrb~soulclbrjb~soulclbr
+souledgea=souledge~esouledgb=souledge1j
+spacebrd=spacedem=spacefb=spacefbb=spacefbg
+spacecho2=spacecho=speakres=stratvoxb=stratvox
+spacedx=spacedxj~spacedxo~spcinvdj
+spaceftr=starcas=starcas1=starcase=starcasp=stellcas
+spaceplt=timeplt=timeplta=timepltc
+spaceshp=spacewar
+spacetrk=spacetrkc
+spacfurya=spacfuryb=spacfury
+spatter=ssanchan
+spbactn=spbactnj
+spcfrcii~=spclforc (energy difference)
+spclordsa~(spclordsb=spclordsg=spclords)
+spelunkrj=spelunkr~=spelunk2
+spf2t=spf2ta=spf2th=spf2xj=spf2xjd
+spfghmk2~=spfghmk22
+spiders=spiders2~spiders3=spinner
+spidman~=spidmanu
+spinlbrkj=spinlbrk=spinlbrku
+splatterj=splattero=splatter
+spool3=spool3i
+spool99=spool99a (unchecked relationship)
+sprcros2=sprcros2a
+sprint1~(sprint2=sprint2a)
+sprint4=sprint4a
+spuzbobl=spuzboblj (unchecked relationship)
+spy=spyu
+spyhunt2a=spyhunt2
+spyhunt=spyhuntp
+srally2=srally2x
+srdarwin=srdarwinj
+srmp4=srmp4o
+sscope=sscopea~sscopeb
+ssf2=ssf2a=ssf2ar1=ssf2h=ssf2j=ssf2jr1=ssf2jr2=ssf2tb=ssf2tbd=ssf2tbj=ssf2tbr1=ssf2tur1=ssf2u=ssf2ud~=(ssf2t=ssf2ta=ssf2tu=ssf2xj=ssf2xjd(UNTESTED ssf2xj,ssf2xjd,ssf2tb,ssf2tbj,ssf2tbr1))
+sshangha=sshanghab
+sshooter11=sshooter12=sshooter
+sslam=sslama
+sspaceatc=sspaceat2=sspaceat3=sspaceat~=(alphaho~=sspacaho~(headon=supcrash~=headons=headonsa~(car2=headon2=headon2s)~headonb))
+sspirtfc=sspiritj=sspirits
+ssridersabd=ssridersebc=ssridersebd=ssridersjbd=ssridersubc~=(ssridersadd=ssriderseaa=ssridersuac=ssridersuda=ssriders=ssridersb)
+starfirea~=starfire
+starglad=stargladj
+starjack=starjacks
+starwars1=starwars
+steeltal1=steeltalp~(steeltalg=steeltal) (steeltalp cheats not checked though!)
+stinger=stinger2
+stkclmnsj=stkclmns
+stonebal2~=stonebal (Only difference is stonebal uses TEAM 1/2 instead of PL1/2 in descriptions)
+strahl~=strahla
+stratab=stratab1
+stratgys=stratgyx=strongx
+streetsm1=streetsmj=streetsm=streetsmw
+strider=striderj=striderjr=striderua
+strnskil=guiness
+stunrun2e=stunrun3e=stunrun=stunrun0=stunrun2=stunrun3=stunrun4=stunrun5=stunrune~=(stunrunj=stunrunp)
+supbtimea=supbtime=supbtimej
+superbar=wiggie
+superman=supermanj
+superpac=superpacm
+superx=superxm
+suprloco=suprlocoa
+suprridr~=timelimt
+suratk=suratka=suratkj
+surfplnt40=surfplnt (unchecked relationship)
+survarts=survartsu
+suzuk8h2=suzuka8hj=suzuka8h
+svc=svcboot=svcpcb=svcpcba~=(svcplus=svcplusa=svcsplus)   [relationship untested]
+svolley=svolleyk=svolleyu
+swcourt=swcourtj
+swimmer=swimmera=swimmerb
+sws96=sws97
+sws~=sws92~=sws92g~=sws93
+swtrilgya=swtrilgy
+szaxxon~zaxxon=zaxxon2=zaxxon3=zaxxonb~=zaxxonj
+tank8=tank8a=tank8b=tank8c=tank8d (tank8a tank8b & tank8d are untested)
+tankfrce=tankfrcej~=tankfrce4 {tankfrc4 is untested - marked as non-working}
+taotaidoa~taotaido
+tattass=tattassa
+tazmani2=tazmania=tazzmang
+tbowl=tbowlj
+tceptor=tceptor2
+tdfever=tdfever2=tdfeverj
+teamqb=teamqb2
+teddybb=teddybbo
+tehkanwc=tehkanwcb=tehkanwcc
+tekken2=tekken2a~tekken2b
+tekken3~tekken3a~tekken3b=tekken3c
+tekken=tekkena~(tekkenb=tekkenc)
+tektagt=tektagta~tektagtb~tektagtc
+tempest=tempest1=tempest2=tempest3=temptube
+tenkomorj=tenkomor
+term2~=term2la1=term2la2=term2la3
+terracren=terracrea=terracre
+terraf=terrafa=terrafb=terrafu
+tetris=tetris1=tetris2=tetris3=tetrisbl~(tetris~tetrista) (tetrist cheats are slightly different in method - I wanted them this way)
+tetrisp2j=tetrisp2
+tfrceac=tfrceacb=tfrceacj
+tharrierj=tharrier
+thegrid=thegrida (unchecked relationship)
+thepit=thepitb=thepitc=thepitm
+thndrbld1=thndrbld
+thndrx2j=thndrx2a
+thunderxa~=(thunderxb=thunderxj=thunderx)
+thundfoxj=thundfoxu=thundfox
+tigerh=tigerhb1=tigerhb2=tigerhb3=tigerhj
+tigeroad=tigeroadb=toramich
+timecris=timecrisa
+timekill131=timekill
+timescan=timescan1
+tinstar=tinstar2
+titlef=titlefu
+tkdenshoa=tkdensho
+tknight=wildfang
+tmek~tmek20
+tmht=tmhta=tmnt=tmntj=tmntu=tmntua~=(tmht2p=tmht2pa=tmnt2p=tmnt2pj=tmnt2po)
+tmnt2=tmnt2a~=tmnt22pu=tmht22pe
+tndrcade=tndrcadej
+tnextspc=tnextspcj
+tnk3=tnk3j
+tnzs=tnzsj~=tnzso
+todruaga=todruagao=todruagas
+tokio=tokiob=tokioo=tokiou
+toki~=(juju=jujub=tokia=tokib=tokiu=tokiua)
+tomahaw5~tomahawk
+tomcat=tomcatw (unchecked relationship)
+toobin=toobin2=toobin2e=toobine=toobing~=toobin1
+tophuntr=tophuntrh
+toride2gg=toride2j~toride2g
+totcarn=totcarnp
+touchgo=touchgoe=touchgon    (unchecked relationship)
+tourtab2=tourtabl
+toutrun=toutrun1=toutrun2=toutrun3
+tp84=tp84a~tp84b
+trckydoca=trckydoc
+triothepj=triothep
+triviabb=triviag2=triviasp=triviayp~=trivia12~=triviag1~=triviaes
+trog=trog3=trog4=trogpa4=trogpa6
+trojan=trojanj=trojanr
+tron=tron2=tron3=tron4
+trvhang=trvhanga (unchecked relationship)
+trvmstr=trvmstra=trvmstrb=trvmstrc
+trvwzha=trvwzhb=trvwzh=trvwz3v=trvwzva=trvwzv~=trvwz2=trvwz2a~trvwz4=trvwz4a~trvwz3h=trvwz3ha
+tsamurai=tsamurai2=tsamuraih
+tshingen=tshingena
+tstrike~=tstrikea (values for max shot power are different)
+ttchamp=ttchampa     (unchecked relationship)
+tturf=tturfbl=tturfu
+tubep~tubepb
+tunhunt=tunhuntc
+turbo=turboa=turbob
+turbosb6=turbosb7=turbosub (unchecked relationship)
+turtshipj=turtshipk=turtship
+tutankhm=tutankhms
+twinadv~=twinadvk
+twinbrat=twinbrata
+twins~twinsa
+twotiger=twotigerc
+twrldc94a=twrldc94     (twrldc94a not working so untested)
+tx1=tx1a
+uccops=uccopsj=uccopsu~=uccopsar (poke value for full energy different & word size)
+ufosensib=ufosensi
+ultennis=ultennisj
+undrfire=undrfirej=undrfireu
+upndown~=upndownu
+usg183~=usg252~(usg32=usg82=usg83=usg83x) [different max values though and games differ - basic locations all the same]
+vamphalfk~vamphalf (add 0x170 onto vamphalfk addresses)
+vandykejal=vandykejal2=vandyke
+vanguardc=vanguard=vanguardj
+vanvan=vanvanb=vanvank
+vaportrx~vaportrxp
+varth=varthj=varthr1=varthu
+vasara2=vasara2a
+vastar=vastar2
+vball~=vball2pj
+vbowl=vbowlj     (unchecked relationship)
+vendetta2p=vendetta2pu=vendettaj=vendetta2pd~=(vendettar=vendett2=vendetta)
+venture=venture2=venture4
+vf2=vf2b=vf2o
+vf3~vf3tb    (unchecked relationship)
+vformula=vr
+victorba~=victory
+vigilant=vigilantj=vigilantu
+vimana=vimana1=vimanan
+vindctr2r1=vindctr2r2=vindctr2~(vindictre3=vindictre4=vindictr1=vindictr2=vindictr4=vindictre=vindictrg=vindictr)
+viofightj=viofight=viofightu
+viostormub=viostorm=viostorma=viostormj=viostormu
+viprp1=viprp1j=viprp1s=viprp1u~=(viprp1oj=viprp1ot)~=viprp1hk (viprp1hk also missing rapid fire)
+vliner=vlinero
+vmetal=vmetaln
+volfied=volfiedj=volfiedu
+von2=von254g       (unchecked relationship)
+von=vonusa     (unchecked relationship)
+vs2~vs215~vs298~vs29815~vs299=vs299b~vs2v991 (vs298, vs299, vs299b & vs2v991 not working)
+vsbballja=vsbballjb=vsbball=vsbballj
+vsnetscra=vsnetscrj=vsnetscr=vsnetscru=vsnetscreb    (unchecked relationship)
+vspinbal=vspinbalj
+vssoccer=vssoccerj
+vstennisj=vstennis
+vstriker=vstrikra    (unchecked relationship)
+vulgus=vulgus2=vulgusj
+wallc=wallca
+warpwarpr2=warpwarp=warpwarpr
+wb3~=(wb31=wb32=wb33=wb34=wb35=wb35a=wb3bbl) {wb35,wb35a untested not working}
+wbdeluxe=wboy=wboy2=wboy2u=wboy3=wboy4=wboyo=wboysys2~=wboyu (wboyu mostly identical but no way of killing level 7 boss so the doll cheat is not needed - and the description for the boss cheat is different)
+wbeachvl2~wbeachvl (+credit differences)
+wbml=wbmlb=wbmlbg=wbmljb=wbmljo
+wc90~=(wc90a=wc90b=wc90b1=wc90b2=wc90t)
+wcbowl=wcbowl161=wcbowl165~wcbowl12=wcbowl13~wcbowl15
+welltrisj=welltris
+wfortunea=wfortune
+wgp=wgpj~=(wgpjoy=wgpjoya)~wgp2
+wh1=wh1h=wh1ha~(wh2~=wh2j=wh2jh~=whp)
+willow=willowj=willowje
+windheat=windheatu (unchecked relationship)
+wingwar=wingwarj=wingwaru
+winspike=winspikej
+wiseguy=yamyam
+wiz=wizt=wizta
+wizzquiz=wizzquiza
+wof=wofa=wofhfb=wofj=wofu
+woodpeca=woodpeck
+wotw=wotwc
+wow=wowg
+wrally=wrallya=wrallyb
+wrestwar1=wrestwar2=wrestwar
+wschamp=wschampa
+ws~=ws89=ws90
+wwallyj=wwallyja
+wwestern1=wwestern
+wwfmania=wwfmaniab
+wwfsstara=wwfsstarj=wwfsstar=wwfsstaru
+wwfwfest=wwfwfesta=wwfwfestb=wwfwfestj
+xexex~=xexexj
+xmcota=xmcotaa=xmcotad=xmcotah=xmcotahr1=xmcotaj=xmcotaj1=xmcotaj2=xmcotaj3=xmcotajr=xmcotau
+xmen=xmene=xmenj~=(xmen2pa=xmen2pe=xmen2pj)~=(xmen6p=xmen6pu)
+xmultipl~xmultiplm72
+xmvsf=xmvsfa=xmvsfar1=xmvsfar2=xmvsfb=xmvsfh=xmvsfj=xmvsfjr1=xmvsfjr2=xmvsfr1=xmvsfu=xmvsfu1d=xmvsfur1
+xybots=xybots1=xybotsf=xybotsg~=xybots0
+yiear=yiear2
+yosakdona=yosakdon
+zaviga=zavigaj
+zeropnt=zeropnta
+zerowing~zerowing2
+zigzag=zigzag2
+zookeep=zookeep2=zookeep3
+
+------------------------------------------------------------------------------
+       SECTION 14     Games which currently have no cheats with reason
+------------------------------------------------------------------------------
+
+The following games do not yet have cheats (Infinite Credits does NOT count as
+a proper cheat) for at least one of the following reasons (not all reasons will be
+used at any one time):-
+
+1.  The game has not yet been properly emulated by MAME or it crashes when
+   I try to play it :-(. Some games which are broken still have cheats -
+   however, if it's NOT properly emulated and no good cheats could be found
+   then reason 1 will be quoted over all other reasons (apart from 3 & 6).
+   I also use this reason if I can't figure out the control method or it's
+   too awkward for me to waste time figuring out. There are LOTs of 'reason 1'
+   and they will not get checked again till they get reported as working.
+
+2.  I don't know what cheats to find as the game is hard to understand and is
+   perhaps in a another tongue - eg Japanese (not including Mahjong games though).
+   Or the the game doesn't appear suitable for cheat finding.
+
+3.  This is a Mahjong/Hanafuda game - I don't do Mahjong games. I'll leave cheat
+   finding on these games to other people. In fact if the game's got Mahjong in
+   the title, this reason will be quoted above all others apart maybe from reason 1.
+
+4.  I've got cheat(s) for the game but I haven't had chance to test them or redo
+   the cheat description(s).
+
+5.  The game was added or fixed in one of the last versions and I haven't had chance
+   to find any cheats yet. If there is no reason quoted, then it is for this
+   reason.
+
+6.  It appears to be gambling or a redemption ticket game, and although cheats are
+   possible they generate little interest. I'm sure if computers had payout bins
+   there would be more cheats....
+
+7.  I've had a quick look at this game and it seems suitable for cheat finding,
+   there's maybe RAM set up, although RAM banking may make RAM searching impossible.
+   but even a simple search for an Infinite Lives cheat
+   didn't turn up any cheats after whittling down the locations.... These can
+   be taken as a challenge!!!
+
+8.  Although it is possible to find cheats for this game, unfortunately the cheats
+   are not constant. IE The next time you load the game (or even reset it) the
+   cheat locations will have changed. This effects a LOT of games, occasionally it
+   is possible to find the odd cheat though as some locations maybe constant. This
+   dynamic memory location problem is quite prevalent in neo-geo fighter games - and
+   there maybe some cheats in the cheat file that don't work and this will be the most
+   likely cause. Relative Address (dynamic memory) Cheats can be often be found for
+   these but it involves a bit more time to find them, this has been put on the backburner.
+
+9.  This game hasn't got any cheats, however there is a clone or parent of this game
+	 which has cheats. It may just need a straight copy of the cheats.
+
+10. Nobody has submitted any cheats for this game and I am so sick and tired of this
+   genre I can't motivate myself to find any cheats for this game. However, I
+   would expect it to be any easy game to find cheats for and you only have to look
+   at games of the same genre to find out which cheats can be found (eg. for baseball
+   games look at another baseball game).
+
+11.  I haven't had chance to look at the game for one reason or another -
+   A COP OUT! ;-) I may have had a look at the game in the past but I can't
+   remember - I will use this reason in that case too. I'll only use this reason
+   if none of the other reasons fit. Expect to see this reason a lot if the cheat
+   file doesn't get updated often enough.
+
+12. This game requires a large chd (eg. Dragon's Lair which requires a massive lossless chd
+		conversion of the laserdisc). The game may or may not work but the size of the chd is a
+		massive hinderance - the availabilty & obtainability may also be an issue. BUT PLEASE
+    DON'T POST/EMAIL ANY LINKS TO ANY OF THE FILES - if you have all the files required and
+		the game works and you want to help then please find the cheats and post them on the
+		cheat	forums.
+
+******************************************************************************
+*     ALL CHEATS REQUIRED GAMES LIST WAS LAST UPDATED ON 03 AUGUST 2010      *
+******************************************************************************
+; { Reason 01 } ; 11beat         [ Eleven Beat ]
+; { Reason 01 } ; 18wheelr       [ 18 Wheeler (JPN) ]
+; { Reason 01 } ; 2mindril       [ Two Minute Drill ]
+; { Reason 01 } ; 3bagflnz       [ 3 Bags Full - 3VXFC5345 (New Zealand) ]
+; { Reason 01 } ; 48in1          [ 48 in 1 MAME bootleg (ver 3.09) ]
+; { Reason 01 } ; 48in1a         [ 48 in 1 MAME bootleg (ver 3.02) ]
+; { Reason 01 } ; 4roses         [ Four Roses (encrypted, set 1) ]
+; { Reason 01 } ; 4rosesa        [ Four Roses (encrypted, set 2) ]
+; { Reason 01 } ; 500gp          [ 500 GP (5GP3 Ver. C) ]
+; { Reason 01 } ; 98best44       [ '98 NeoPri Best 44 (Neo Print) ]
+; { Reason 01 } ; a51site4       [ Area 51: Site 4 ]
+; { Reason 01 } ; abacus         [ Abacus (Ver 1.0) ]
+; { Reason 01 } ; acommand       [ Alien Command ]
+; { Reason 01 } ; adders         [ Adders and Ladders (v2.0) ]
+; { Reason 01 } ; adonis         [ Adonis (A - 25-05-98, NSW/ACT) ]
+; { Reason 01 } ; airtrix        [ Air Trix ]
+; { Reason 01 } ; alpilota       [ Airline Pilots (Rev A) ]
+; { Reason 01 } ; alpiltdx       [ Airline Pilots Deluxe (Rev B) ]
+; { Reason 01 } ; alpinr2a       [ Alpine Racer 2 (Rev. ARS2 Ver.A) ]
+; { Reason 01 } ; amclink        [ Amcoe Link Control Box (Version 2.2) ]
+; { Reason 01 } ; am_mg24        [ Multi Game I (V.Ger 2.4) ]
+; { Reason 01 } ; am_mg3         [ Multi Game III (V.Ger 3.5) ]
+; { Reason 01 } ; am_uslot       [ Amatic Unknown Slots Game ]
+; { Reason 01 } ; atamanot       [ Computer Quiz Atama no Taisou (Japan) ]
+; { Reason 01 } ; avalon13       [ The Key Of Avalon 1.3 - Chaotic Sabbat - Client (GDT-0010C) (V4.000) ]
+; { Reason 01 } ; avalon20       [ The Key Of Avalon 2.0 - Eutaxy and Commandment - Client (GDT-0017B) (V3.001) ]
+; { Reason 01 } ; avalons        [ The Key Of Avalon - The Wizard Master - Server (GDT-0005C) (V4.001) ]
+; { Reason 01 } ; azumanga       [ Azumanga Daioh Puzzle Bobble (GDL-0018) ]
+; { Reason 01 } ; backgamn       [ Backgammon ]
+; { Reason 01 } ; bass           [ Sega Bass Fishing ]
+; { Reason 01 } ; batlgear       [ Battle Gear ]
+; { Reason 01 } ; batlgr2        [ Battle Gear 2 ]
+; { Reason 01 } ; bballoon       [ Balloon & Balloon ]
+; { Reason 01 } ; bbprot         [ unknown fighting game 'BB' (prototype) ]
+; { Reason 01 } ; bbust2         [ Beast Busters 2nd Nightmare ]
+; { Reason 01 } ; bdrdown        [ Border Down (Rev A) (GDL-0023A) ]
+; { Reason 01 } ; beachspi       [ Beach Spikers (GDS-0014) ]
+; { Reason 01 } ; beeline        [ Beeline (39-360-075) ]
+; { Reason 01 } ; begas          [ Bega's Battle (Revision 3) ]
+; { Reason 01 } ; begas1         [ Bega's Battle (Revision 1) ]
+; { Reason 01 } ; bel            [ Behind Enemy Lines ]
+; { Reason 01 } ; bigd2          [ Big D2 ]
+; { Reason 01 } ; bingor1        [ Bingo Roll / Bell Star? (set 1) ]
+; { Reason 01 } ; bingor2        [ Bingo Roll / Bell Star? (set 2) ]
+; { Reason 01 } ; bingor3        [ Bingo Roll / Bell Star? (set 3) ]
+; { Reason 01 } ; bingor4        [ Bingo Roll / Bell Star? (set 4) ]
+; { Reason 01 } ; blkrhino       [ Black Rhino - 3VXFC5344 (New Zealand) ]
+; { Reason 01 } ; blox           [ Blox (v2.0) ]
+; { Reason 01 } ; bloxd          [ Blox (v2.0, Datapak) ]
+; { Reason 01 } ; bmiidx         [ beatmania IIDX (863 JAA) ]
+; { Reason 01 } ; bmiidx3        [ beatmania IIDX 3th style (GC992 JA) ]
+; { Reason 01 } ; bonanza        [ Bonanza (Revision 3) ]
+; { Reason 01 } ; bonanzar2      [ Bonanza (Revision 2) ]
+; { Reason 01 } ; bookthr        [ Book Theatre (Ver 1.2) ]
+; { Reason 01 } ; boxingm        [ Boxing Mania (ver JAA) ]
+; { Reason 01 } ; brickzn        [ Brick Zone (v5.0) ]
+; { Reason 01 } ; brickzn3       [ Brick Zone (v4.0) ]
+; { Reason 01 } ; btchamp        [ Beat the Champ (GV053 UAA01) ]
+; { Reason 01 } ; btltryst       [ Battle Tryst (ver JAC) ]
+; { Reason 01 } ; buriki         [ Buriki One (rev.B) ]
+; { Reason 01 } ; cabaret        [ Cabaret ]
+; { Reason 01 } ; cafebrk        [ Mahjong Cafe Break ]
+; { Reason 01 } ; cafedoll       [ Mahjong Cafe Doll (Japan) ]
+; { Reason 01 } ; calchase       [ California Chase ]
+; { Reason 01 } ; capcor         [ Capitani Coraggiosi (Ver 1.3) ]
+; { Reason 01 } ; capsnk         [ Capcom Vs. SNK Millennium Fight 2000 (000904 JPN, USA, EXP, KOR, AUS) (Rev C) ]
+; { Reason 01 } ; capsnka        [ Capcom Vs. SNK Millennium Fight 2000 (000804 JPN, USA, EXP, KOR, AUS) (Rev A) ]
+; { Reason 01 } ; capunc         [ Capitan Uncino (Ver 1.2) ]
+; { Reason 01 } ; cartfury       [ Cart Fury ]
+; { Reason 01 } ; catapult       [ Catapult ]
+; { Reason 01 } ; cb3c           [ Cherry Bonus III (alt, set 2) ]
+; { Reason 01 } ; cfield         [ Chaos Field (GDL-0025) ]
+; { Reason 01 } ; champbb2j      [ Champion Baseball II (Japan) ]
+; { Reason 01 } ; chkun          [ Chance Kun ]
+; { Reason 01 } ; chocomk        [ Musapey's Choco Marker (Rev A) (GDL-0014A) ]
+; { Reason 01 } ; cleoftp        [ Cleopatra Fortune Plus (GDL-0012) ]
+; { Reason 01 } ; clubkrte       [ Club Kart: European Session ]
+; { Reason 01 } ; cmagica        [ Carta Magica (Ver 1.8) ]
+; { Reason 01 } ; cmkenosp       [ Coinmaster Keno (Y2K, Spanish, 2000-12-14) ]
+; { Reason 01 } ; cmkenospa      [ Coinmaster Keno (Y2K, Spanish, 2000-12-02) ]
+; { Reason 01 } ; cmmb162        [ Multipede (V1.00) ]
+; { Reason 01 } ; cmrltv75       [ Coinmaster Roulette V75 (Y2K, Spanish) ]
+; { Reason 01 } ; cntsteer       [ Counter Steer (Japan) ]
+; { Reason 01 } ; code1d         [ Code One Dispatch (ver D) ]
+; { Reason 01 } ; code1db        [ Code One Dispatch (ver B) ]
+; { Reason 01 } ; colorama       [ Colorama (English) ]
+; { Reason 01 } ; comebaby       [ Come On Baby ]
+; { Reason 01 } ; comg079        [ Cal Omega - Game 7.9 (Arcade Poker) ]
+; { Reason 01 } ; comg080        [ Cal Omega - Game 8.0 (Arcade Black Jack) ]
+; { Reason 01 } ; comg094        [ Cal Omega - Game 9.4 (Keno) ]
+; { Reason 01 } ; comg107        [ Cal Omega - Game 10.7c (Big Game) ]
+; { Reason 01 } ; comg123        [ Cal Omega - Game 12.3 (Ticket Poker) ]
+; { Reason 01 } ; comg125        [ Cal Omega - Game 12.5 (Bingo) ]
+; { Reason 01 } ; comg127        [ Cal Omega - Game 12.7 (Keno) ]
+; { Reason 01 } ; comg134        [ Cal Omega - Game 13.4 (Nudge Bingo) ]
+; { Reason 01 } ; comg145        [ Cal Omega - Game 14.5 (Pixels) ]
+; { Reason 01 } ; comg157        [ Cal Omega - Game 15.7 (Double-Draw Poker) ]
+; { Reason 01 } ; comg159        [ Cal Omega - Game 15.9 (Wild Double-Up) ]
+; { Reason 01 } ; comg164        [ Cal Omega - Game 16.4 (Keno) ]
+; { Reason 01 } ; comg168        [ Cal Omega - Game 16.8 (Keno) ]
+; { Reason 01 } ; comg172        [ Cal Omega - Game 17.2 (Double Double Poker) ]
+; { Reason 01 } ; comg176        [ Cal Omega - Game 17.6 (Nudge Bingo) ]
+; { Reason 01 } ; comg181        [ Cal Omega - Game 18.1 (Nudge Bingo) ]
+; { Reason 01 } ; comg183        [ Cal Omega - Game 18.3 (Pixels) ]
+; { Reason 01 } ; comg185        [ Cal Omega - Game 18.5 (Pixels) ]
+; { Reason 01 } ; comg186        [ Cal Omega - Game 18.6 (Pixels) ]
+; { Reason 01 } ; comg187        [ Cal Omega - Game 18.7 (Amusement Poker) ]
+; { Reason 01 } ; comg204        [ Cal Omega - Game 20.4 (Super Blackjack) ]
+; { Reason 01 } ; comg208        [ Cal Omega - Game 20.8 (Winner's Choice) ]
+; { Reason 01 } ; comg227        [ Cal Omega - Game 22.7 (Amusement Poker, d/d) ]
+; { Reason 01 } ; comg230        [ Cal Omega - Game 23.0 (FC Bingo (4-card)) ]
+; { Reason 01 } ; comg236        [ Cal Omega - Game 23.6 (Hotline) ]
+; { Reason 01 } ; comg246        [ Cal Omega - Game 24.6 (Hotline) ]
+; { Reason 01 } ; comg272a       [ Cal Omega - Game 27.2 (Keno, amusement) ]
+; { Reason 01 } ; comg272b       [ Cal Omega - Game 27.2 (Keno, gaming) ]
+; { Reason 01 } ; confmiss       [ Confidential Mission (GDS-0001) ]
+; { Reason 01 } ; connect4       [ Connect 4 ]
+; { Reason 01 } ; conquer        [ Conquer ]
+; { Reason 01 } ; coolridr       [ Cool Riders (US) ]
+; { Reason 01 } ; coralr2        [ Coral Riches II - 1VXFC5472 (New Zealand) ]
+; { Reason 01 } ; cowrace        [ Cow Race (1986 King Derby hack) ]
+; { Reason 01 } ; crackndj       [ Crackin' DJ ]
+; { Reason 01 } ; crisscrs       [ Criss Cross (Sweden) ]
+; { Reason 01 } ; crmaze         [ The Crystal Maze (v1.3) ]
+; { Reason 01 } ; crmaze2        [ The New Crystal Maze Featuring Ocean Zone (v2.2) ]
+; { Reason 01 } ; crmaze2a       [ The New Crystal Maze Featuring Ocean Zone (v0.1, AMLD) ]
+; { Reason 01 } ; crmaze2d       [ The New Crystal Maze Featuring Ocean Zone (v2.2d) ]
+; { Reason 01 } ; crmaze3        [ The Crystal Maze Team Challenge (v0.9) ]
+; { Reason 01 } ; crmaze3a       [ The Crystal Maze Team Challenge (v1.2, AMLD) ]
+; { Reason 01 } ; crmaze3d       [ The Crystal Maze Team Challenge (v0.9, Datapak) ]
+; { Reason 01 } ; crmazea        [ The Crystal Maze (v0.1, AMLD) ]
+; { Reason 01 } ; crmazed        [ The Crystal Maze (v1.3, Datapak) ]
+; { Reason 01 } ; crszone        [ Crisis Zone (CSZO3 Ver. B) ]
+; { Reason 01 } ; crusnexo       [ Cruis'n Exotica (version 2.4) ]
+; { Reason 01 } ; crusnexoa      [ Cruis'n Exotica (version 2.0) ]
+; { Reason 01 } ; crusnexob      [ Cruis'n Exotica (version 1.6) ]
+; { Reason 01 } ; crzytaxi       [ Crazy Taxi (JPN, USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; csmash         [ Cosmic Smash (JPN, USA, EXP, KOR, AUS) (Rev A) ]
+; { Reason 01 } ; csmasho        [ Cosmic Smash (JPN, USA, EXP, KOR, AUS) (original) ]
+; { Reason 01 } ; cspike         [ Gun Spike (JPN) / Cannon Spike (USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; cstripxi       [ Casino Strip XI ]
+; { Reason 01 } ; cultname       [ Seimei-Kantei-Meimei-Ki Cult Name ]
+; { Reason 01 } ; cupsocsb2      [ Seibu Cup Soccer :Selection: (bootleg, set 2) ]
+; { Reason 01 } ; cvs2gd         [ Capcom Vs. SNK 2 Millionaire Fighting 2001 (Rev A) (GDL-0007A) ]
+; { Reason 01 } ; cvsgd          [ Capcom Vs. SNK Millenium Fight 2000 Pro (GDL-0004) ]
+; { Reason 01 } ; cyclemb        [ Cycle Mahbou (Japan) ]
+; { Reason 01 } ; dangcurv       [ Dangerous Curves ]
+; { Reason 01 } ; dayto2pe       [ Daytona USA 2 Power Edition ]
+; { Reason 01 } ; daytona2       [ Daytona USA 2 (Revision A) ]
+; { Reason 01 } ; ddragon6809    [ Double Dragon (bootleg with 3xM6809, set 1) ]
+; { Reason 01 } ; ddragon6809a   [ Double Dragon (bootleg with 3xM6809, set 2) ]
+; { Reason 01 } ; ddz            [ Dou Di Zhu ]
+; { Reason 01 } ; deathcox       [ Death Crimson OX (JPN, USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; decathlt       [ Decathlete (JUET 960709 V1.001) ]
+; { Reason 01 } ; decathlto      [ Decathlete (JUET 960424 V1.000) ]
+; { Reason 01 } ; defndjeu       [ Defender (bootleg) ]
+; { Reason 01 } ; demofist       [ Demolish Fist ]
+; { Reason 01 } ; dendeg         [ Densya De Go (Japan) ]
+; { Reason 01 } ; dendeg2        [ Densya De Go 2 (Japan) ]
+; { Reason 01 } ; dendeg2x       [ Densya De Go 2 Ex (Japan) ]
+; { Reason 01 } ; dendegx        [ Densya De Go Ex (Japan) ]
+; { Reason 01 } ; denjinmk       [ Denjin Makai ]
+; { Reason 01 } ; derbyoc        [ Derby Owners Club (JPN, USA, EXP, KOR, AUS) (Rev B) ]
+; { Reason 01 } ; derbyoc2       [ Derby Owners Club II (JPN, USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; derbyocw       [ Derby Owners Club World Edition (JPN, USA, EXP, KOR, AUS) (Rev C) ]
+; { Reason 01 } ; desert         [ Desert Tank ]
+; { Reason 01 } ; deshoros       [ Destiny Horoscope ]
+; { Reason 01 } ; dirtdash       [ Dirt Dash (Rev. DT2) ]
+; { Reason 01 } ; dirtdvls       [ Dirt Devils (Revision A) ]
+; { Reason 01 } ; dirtdvlsa      [ Dirt Devils (alt) (Revision A) ]
+; { Reason 01 } ; dmdtouch       [ Diamond Touch (E - 30-06-97, Local) ]
+; { Reason 01 } ; dmndrby        [ Diamond Derby (Newer) ]
+; { Reason 01 } ; dmndrbya       [ Diamond Derby (Original) ]
+; { Reason 01 } ; dmnfrnt        [ Demon Front (ver. 102) ]
+; { Reason 01 } ; dmnfrnta       [ Demon Front (ver. 105) ]
+; { Reason 01 } ; doa            [ Dead or Alive (Model 2B, Revision B) ]
+; { Reason 01 } ; doa2           [ Dead or Alive 2 (JPN, USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; doa2m          [ Dead or Alive 2 Millennium (JPN, USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; doaa           [ Dead or Alive (Model 2A, Revision A) ]
+; { Reason 01 } ; dodge          [ Dodge City ]
+; { Reason 01 } ; dolphntr       [ Dolphin Treasure (B - 06/12/96, NSW/ACT, Rev 1.24.4.0) ]
+; { Reason 01 } ; dolphtra       [ Dolphin Treasure (B - 06/12/96, NSW/ACT, Rev 3) ]
+; { Reason 01 } ; doncdoon       [ Donchan no Hanabi de Doon ]
+; { Reason 01 } ; downhill       [ Downhill Bikers (DH3 Ver. A) ]
+; { Reason 01 } ; dphljp         [ Draw Poker HI-LO (Japanese) ]
+; { Reason 01 } ; dphlunka       [ Draw Poker HI-LO (unknown, rev 1) ]
+; { Reason 01 } ; dphlunkb       [ Draw Poker HI-LO (unknown, rev 2) ]
+; { Reason 01 } ; dragchrn       [ Dragon Chronicles (DC001 Ver. A) ]
+; { Reason 01 } ; drgw3          [ Dragon World 3 (ver. 106, Korean Board) ]
+; { Reason 01 } ; drgw3100       [ Dragon World 3 (ver. 100) ]
+; { Reason 01 } ; drgw3105       [ Dragon World 3 (ver. 105) ]
+; { Reason 01 } ; driveyes       [ Driver's Eyes (US) ]
+; { Reason 01 } ; drw80pkr       [ Draw 80 Poker ]
+; { Reason 01 } ; dsem           [ Dancing Stage Euro Mix (G*936 VER. EAA) ]
+; { Reason 01 } ; dsfdct         [ Dancing Stage featuring Dreams Come True (GC910 VER. JCA) ]
+; { Reason 01 } ; dsfdr          [ Dancing Stage Featuring Disney's Rave (GCA37JAA) ]
+; { Reason 01 } ; dvisland       [ Devil Island ]
+; { Reason 01 } ; dw2001         [ Dragon World 2001 ]
+; { Reason 01 } ; dwex           [ Dragon World 3 EX (ver. 100) ]
+; { Reason 01 } ; dybb99         [ Dynamite Baseball '99 (JPN) / World Series '99 (USA, EXP, KOR, AUS) (Rev B) ]
+; { Reason 01 } ; dybbnao        [ Dynamite Baseball NAOMI (JPN) ]
+; { Reason 01 } ; dygolf         [ Virtua Golf / Dynamic Golf (Rev A) (GDS-0009A) ]
+; { Reason 01 } ; dynamcopb      [ Dynamite Cop (Export, Model 2B) ]
+; { Reason 01 } ; dynamcopc      [ Dynamite Cop (USA, Model 2C) ]
+; { Reason 01 } ; dyndeka2       [ Dynamite Deka 2 (Japan, Model 2A) ]
+; { Reason 01 } ; dyndeka2b      [ Dynamite Deka 2 (Japan, Model 2B) ]
+; { Reason 01 } ; eca            [ Emergency Call Ambulance ]
+; { Reason 01 } ; ecax           [ Emergency Call Ambulance (Export) ]
+; { Reason 01 } ; eforest        [ Enchanted Forest - 12XF528902 ]
+; { Reason 01 } ; eforesta       [ Enchanted Forest - 4VXFC818 ]
+; { Reason 01 } ; eforestb       [ Enchanted Forest - 3VXFC5343 (New Zealand) ]
+; { Reason 01 } ; ejollyx5       [ Euro Jolly X5 ]
+; { Reason 01 } ; elandore       [ Touryuu Densetsu Elan-Doree / Elan Doree - Legend of Dragoon (JUET 980922 V1.006) ]
+; { Reason 01 } ; elvis          [ Elvis? ]
+; { Reason 01 } ; enchfrst       [ Enchanted Forest (E - 23/06/95, Local) ]
+; { Reason 01 } ; euro2k2        [ Europa 2002 (Ver 2.0, set 1) ]
+; { Reason 01 } ; euro2k2a       [ Europa 2002 (Ver 2.0, set 2) ]
+; { Reason 01 } ; euro2k2s       [ Europa 2002 Space (Ver 3.0) ]
+; { Reason 01 } ; europass       [ Euro Pass (Ver 1.1) ]
+; { Reason 01 } ; evilngt        [ Evil Night (ver EAA) ]
+; { Reason 01 } ; eyesdown       [ Eyes Down (v1.3) ]
+; { Reason 01 } ; eyesdownd      [ Eyes Down (v1.3, Datapak) ]
+; { Reason 01 } ; f1lap          [ F1 Super Lap ]
+; { Reason 01 } ; f355           [ Ferrari F355 Challenge ]
+; { Reason 01 } ; f355twin       [ Ferrari F355 Challenge (Twin) ]
+; { Reason 01 } ; f355twn2       [ Ferrari F355 Challenge 2 (Twin) ]
+; { Reason 01 } ; fashiong       [ Fashion Gambler ]
+; { Reason 01 } ; fastdrwp       [ Fast Draw (poker conversion kit)? ]
+; { Reason 01 } ; fenix          [ Fenix (bootleg of Phoenix) ]
+; { Reason 01 } ; ffreveng       [ Final Fight Revenge (JUET 990714 V1.000) ]
+; { Reason 01 } ; fghtjam        [ Capcom Fighting Jam (JAM1 Ver. A) ]
+; { Reason 01 } ; findlove       [ Find Love (J 971212 V1.000) ]
+; { Reason 01 } ; finfurl2       [ Final Furlong 2 (World) ]
+; { Reason 01 } ; finfurl2j      [ Final Furlong 2 (Japan) ]
+; { Reason 01 } ; finlarch       [ Final Arch (J 950714 V1.001) ]
+; { Reason 01 } ; finlflng       [ Final Furlong (FF2 Ver. A) ]
+; { Reason 01 } ; fmania         [ Fighting Mania (918 xx B02) ]
+; { Reason 01 } ; fortecar       [ Forte Card ]
+; { Reason 01 } ; fotns          [ Fist Of The North Star ]
+; { Reason 01 } ; fstation       [ Fun Station Spielekoffer 9 Spiele ]
+; { Reason 01 } ; futflash       [ Future Flash ]
+; { Reason 01 } ; fvipers        [ Fighting Vipers (Revision D) ]
+; { Reason 01 } ; fvipers2       [ Fighting Vipers 2 (Revision A) ]
+; { Reason 01 } ; gal3           [ Galaxian 3 - Theater 6 : Project Dragoon ]
+; { Reason 01 } ; gamecst2       [ GameCristal (version 2.613) ]
+; { Reason 01 } ; gamecstl       [ GameCristal ]
+; { Reason 01 } ; gamshara       [ Gamshara (10021 Ver.A) ]
+; { Reason 01 } ; geishanz       [ Geisha (A - 05/03/01, New Zealand) ]
+; { Reason 01 } ; gekpurya       [ Gekitou Pro Yakyuu Mizushima Shinji All Stars vs. Pro Yakyuu (Rev C) (GDT-0008C) ]
+; { Reason 01 } ; getbass        [ Get Bass ]
+; { Reason 01 } ; ggconnie       [ Go! Go! Connie chan Jaka Jaka Janken ]
+; { Reason 01 } ; ggisuka        [ Guilty Gear Isuka ]
+; { Reason 01 } ; ggram2         [ Giant Gram (JPN, USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; ggx            [ Guilty Gear X (JPN) ]
+; { Reason 01 } ; ggxx           [ Guilty Gear XX (GDL-0011) ]
+; { Reason 01 } ; ggxxac         [ Guilty Gear XX Accent Core (GDL-0041) ]
+; { Reason 01 } ; ggxxrl         [ Guilty Gear XX #Reload (Rev A) (GDL-0019A) ]
+; { Reason 01 } ; ggxxsla        [ Guilty Gear XX Slash (Rev A) (GDL-0033A) ]
+; { Reason 01 } ; ghostsqu       [ Ghost Squad (Ver. A?) (GDX-0012A) ]
+; { Reason 01 } ; gigas          [ Gigas (MC-8123, 317-5002) ]
+; { Reason 01 } ; gjspace        [ Gekitoride-Jong Space (10011 Ver.A) ]
+; { Reason 01 } ; glass          [ Glass (Ver 1.1) ]
+; { Reason 01 } ; glass10        [ Glass (Ver 1.0) ]
+; { Reason 01 } ; glassbrk       [ Glass (Ver 1.0, Break Edition) ]
+; { Reason 01 } ; glpracr2       [ Gallop Racer 2 (USA) ]
+; { Reason 01 } ; glpracr2j      [ Gallop Racer 2 (Japan) ]
+; { Reason 01 } ; glpracr2l      [ Gallop Racer 2 Link HW (Japan) ]
+; { Reason 01 } ; gobyrc         [ Go By RC (V2.03O) ]
+; { Reason 01 } ; godzilla       [ Godzilla ]
+; { Reason 01 } ; goldenc        [ Golden Canaries - 1VXFC5462 ]
+; { Reason 01 } ; goldprmd       [ Golden Pyramids (B - 13-05-97, USA) ]
+; { Reason 01 } ; gp98           [ Grand Prix '98 ]
+; { Reason 01 } ; gram2000       [ Giant Gram 2000 (JPN, USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; grandprx       [ Grand Prix ]
+; { Reason 01 } ; greenber       [ Green Beret (Irem) ]
+; { Reason 01 } ; gtfrk3ma       [ Guitar Freaks 3rd Mix (GE949 VER. JAB) ]
+; { Reason 01 } ; gtfrk3mb       [ Guitar Freaks 3rd Mix - security cassette versionup (949JAZ02) ]
+; { Reason 01 } ; gticlub        [ GTI Club (ver EAA) ]
+; { Reason 01 } ; gticlub2       [ GTI Club 2 (ver JAB) ]
+; { Reason 01 } ; gticlub2ea     [ GTI Club 2 (ver EAA) ]
+; { Reason 01 } ; gticluba       [ GTI Club (ver AAA) ]
+; { Reason 01 } ; gticlubj       [ GTI Club (ver JAA) ]
+; { Reason 01 } ; gtipoker       [ GTI Poker ]
+; { Reason 01 } ; gtrfrk6m       [ Guitar Freaks 6th Mix (G*B06 VER. JAA) ]
+; { Reason 01 } ; gtrfrk7m       [ Guitar Freaks 7th Mix (G*B17 VER. JAA) ]
+; { Reason 01 } ; gundamos       [ Gundam Battle Operating Simulator (GDX-0013) ]
+; { Reason 01 } ; gundmgd        [ Mobile Suit Gundam: Federation VS Zeon (GDL-0001) ]
+; { Reason 01 } ; gundmxgd       [ Mobile Suit Gundam: Federation VS Zeon DX  (GDL-0006) ]
+; { Reason 01 } ; gunpey         [ Gunpey ]
+; { Reason 01 } ; gunsur2        [ Gun Survivor 2: Bio Hazard Code Veronica ]
+; { Reason 01 } ; gunwars        [ Gunmen Wars (GM1 Ver. A) ]
+; { Reason 01 } ; gwing2         [ Giga Wing 2 (JPN, USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; hangplt        [ Hang Pilot ]
+; { Reason 01 } ; happy6         [ Happy 6-in-1 (ver. 101CN) ]
+; { Reason 01 } ; hapytour       [ Happy Tour ]
+; { Reason 01 } ; harem          [ Harem ]
+; { Reason 01 } ; harley         [ Harley-Davidson and L.A. Riders (Revision A) ]
+; { Reason 01 } ; heatof11       [ Heat of Eleven '98 (ver EAA) ]
+; { Reason 01 } ; hellngt        [ Hell Night (ver EAA) ]
+; { Reason 01 } ; hipai          [ Hi Pai Paradise ]
+; { Reason 01 } ; hmgeo          [ Heavy Metal Geomatrix (JPN, USA, EUR, ASI, AUS) (Rev A) ]
+; { Reason 01 } ; hotd2          [ House of the Dead 2 ]
+; { Reason 01 } ; hotd2o         [ House of the Dead 2 (original) ]
+; { Reason 01 } ; hotd3          [ The House of the Dead III (GDX-0001) ]
+; { Reason 01 } ; hshavoc        [ High Seas Havoc ]
+; { Reason 01 } ; hvyunit        [ Heavy Unit (World) ]
+; { Reason 01 } ; hvyunitj       [ Heavy Unit (Japan, Newer) ]
+; { Reason 01 } ; hvyunito       [ Heavy Unit (Japan, Older) ]
+; { Reason 01 } ; ikaruga        [ Ikaruga (GDL-0010) ]
+; { Reason 01 } ; ilpag          [ Il Pagliaccio (Italy, Version 2.7C) ]
+; { Reason 01 } ; indiandr       [ Indian Dreaming (B - 15/12/98, Local) ]
+; { Reason 01 } ; indy500        [ INDY 500 Twin (Revision A, Newer) ]
+; { Reason 01 } ; indy500d       [ INDY 500 Deluxe (Revision A) ]
+; { Reason 01 } ; indy500to      [ INDY 500 Twin (Revision A) ]
+; { Reason 01 } ; initd          [ Initial D Arcade Stage (Rev B) (Japan) (GDS-0020B) ]
+; { Reason 01 } ; initdexp       [ Initial D Arcade Stage (Export) (GDS-0025) ]
+; { Reason 01 } ; initdv2j       [ Initial D : Arcade Stage Ver. 2 (Japan) (GDS-0026) ]
+; { Reason 01 } ; initdv3j       [ Initial D : Arcade Stage Ver. 3 (Japan) (Rev B) (GDS-0032B) ]
+; { Reason 01 } ; inquiztr       [ Inquizitor ]
+; { Reason 01 } ; intrscti       [ Intersecti ]
+; { Reason 01 } ; inttoote       [ International Toote (Germany) ]
+; { Reason 01 } ; inttootea      [ International Toote II (World?) ]
+; { Reason 01 } ; ipminvad1      [ IPM Invader (Incomplete Dump) ]
+; { Reason 01 } ; iqpipe         [ IQ Pipe ]
+; { Reason 01 } ; jambo          [ Jambo! Safari (JPN, USA, EXP, KOR, AUS) (Rev A) ]
+; { Reason 01 } ; janshi         [ Janshi ]
+; { Reason 01 } ; jansou         [ Jansou (set 1) ]
+; { Reason 01 } ; jclub2         [ Jockey Club II (newer hardware) ]
+; { Reason 01 } ; jclub2o        [ Jockey Club II (older hardware) ]
+; { Reason 01 } ; jingystm       [ Jingi Storm - The Arcade (GDL-0037) ]
+; { Reason 01 } ; jkrmast        [ Joker Master ]
+; { Reason 01 } ; jnero          [ Johnny Nero Action Hero ]
+; { Reason 01 } ; jokercrd       [ Joker Card (Ver.A267BC, encrypted) ]
+; { Reason 01 } ; jolycdab       [ Jolly Card (Austrian, Funworld, bootleg) ]
+; { Reason 01 } ; jpark3         [ Jurassic Park 3 (ver EBC) ]
+; { Reason 01 } ; kaiunqz        [ Kaiun Quiz (Japan, KW1/VER.A) ]
+; { Reason 01 } ; karous         [ Karous (GDL-0040) ]
+; { Reason 01 } ; kbm            [ Keyboardmania ]
+; { Reason 01 } ; kbm3rd         [ Keyboardmania 3rd Mix ]
+; { Reason 01 } ; kdeadeye       [ Dead Eye (GV054 UA01) ]
+; { Reason 01 } ; keyboard       [ La Keyboardxyu (GDS-0017) ]
+; { Reason 01 } ; kftgoal        [ Kick for the Goal ]
+; { Reason 01 } ; kgbird         [ K.G Bird - 4VXFC5341 (New Zealand, 87.98%) ]
+; { Reason 01 } ; kgbirda        [ K.G Bird - 4VXFC5341 (New Zealand, 91.97%) ]
+; { Reason 01 } ; kick4csh       [ Kick '4' Cash ]
+; { Reason 01 } ; kimbldhl       [ Kimble Double HI-LO ]
+; { Reason 01 } ; kimblz80       [ Kimble Double HI-LO (z80 version) ]
+; { Reason 01 } ; kingtut        [ King Tut (NSW) ]
+; { Reason 01 } ; kinniku        [ Kinnikuman Muscle Grand Prix (KN1 Ver. A) ]
+; { Reason 01 } ; kisekaem       [ Kisekae Mahjong ]
+; { Reason 01 } ; klxyj          [ Kuai Le Xi You Ji ]
+; { Reason 01 } ; knightsb       [ Knights of the Round (bootleg) ]
+; { Reason 01 } ; knpuzzle       [ Kotoba no Puzzle Mojipittan (Japan, KPM1 Ver.A) ]
+; { Reason 01 } ; kofnw          [ The King of Fighters Neowave ]
+; { Reason 01 } ; kofnwj         [ The King of Fighters Neowave (Japan) ]
+; { Reason 01 } ; kokoroj2       [ Kokoroji 2 ]
+; { Reason 01 } ; kopunch        [ KO Punch ]
+; { Reason 01 } ; kungfur        [ Kung Fu Roushi ]
+; { Reason 01 } ; kurucham       [ Kurukuru Chameleon (GDL-0034) ]
+; { Reason 01 } ; kurufev        [ Kurukuru Fever ]
+; { Reason 01 } ; lamachin       [ L.A. Machineguns ]
+; { Reason 01 } ; landgear       [ Landing Gear ]
+; { Reason 01 } ; landhigh       [ Landing High Japan ]
+; { Reason 01 } ; laperla        [ La Perla Nera (Ver 2.0) ]
+; { Reason 01 } ; laperlag       [ La Perla Nera Gold (Ver 2.0) ]
+; { Reason 01 } ; laser2k1       [ Laser 2001 (Ver 1.2) ]
+; { Reason 01 } ; laserbas       [ Laser Base (set 1) ]
+; { Reason 01 } ; laserbasa      [ Laser Base (set 2) ]
+; { Reason 01 } ; lastbrnx       [ Last Bronx (Export, Revision A) ]
+; { Reason 01 } ; lastbrnxj      [ Last Bronx (Japan, Revision A) ]
+; { Reason 01 } ; leader         [ Leader ]
+; { Reason 01 } ; lemans24       [ LeMans 24 ]
+; { Reason 01 } ; lhzb3          [ Long Hu Zheng Ba 3 ]
+; { Reason 01 } ; lhzb4          [ Long Hu Zheng Ba 4 ]
+; { Reason 01 } ; littlerb       [ Little Robin ]
+; { Reason 01 } ; lohtb          [ Legend of Hero Tonma (bootleg, set 1) ]
+; { Reason 01 } ; lostwsga       [ The Lost World ]
+; { Reason 01 } ; lupinsho       [ Lupin The Third - The Shooting (GDS-0018) ]
+; { Reason 01 } ; luptype        [ Lupin The Third - The Typing (Rev A) (GDS-0021A) ]
+; { Reason 01 } ; magic102       [ Magic's 10 2 (ver 1.1) ]
+; { Reason 01 } ; magicd2a       [ Magic Card II (green TAB or Impera board) ]
+; { Reason 01 } ; magicd2b       [ Magic Card II (blue TAB board, encrypted) ]
+; { Reason 01 } ; magicmsk       [ Magic Mask (A - 09/05/2000, Export)) ]
+; { Reason 01 } ; magictg        [ Magic the Gathering: Armageddon (set 1) ]
+; { Reason 01 } ; magictga       [ Magic the Gathering: Armageddon (set 2) ]
+; { Reason 01 } ; magtruck       [ Magical Truck Adventure ]
+; { Reason 01 } ; magzun         [ Magical Zunou Power (J 961031 V1.000) ]
+; { Reason 01 } ; manxtt         [ Manx TT Superbike (Revision C) ]
+; { Reason 01 } ; mating         [ The Mating Game (v0.4) ]
+; { Reason 01 } ; matingd        [ The Mating Game (v0.4, Datapak) ]
+; { Reason 01 } ; mayjin3        [ Mayjinsen 3 ]
+; { Reason 01 } ; mayjinsn       [ Mayjinsen ]
+; { Reason 01 } ; mazerbla       [ Mazer Blazer (set 1) ]
+; { Reason 01 } ; mazerblaa      [ Mazer Blazer (set 2) ]
+; { Reason 01 } ; mclass         [ Magic Class (Ver 2.2) ]
+; { Reason 01 } ; mcolors        [ Magic Colors (ver. 1.7a) ]
+; { Reason 01 } ; mdhorse        [ Derby Quiz My Dream Horse (Japan, MDH1/VER.A2) ]
+; { Reason 01 } ; mdrawpkr       [ Draw Poker Joker's Wild (Standard) ]
+; { Reason 01 } ; mdrawpkra      [ Draw Poker Joker's Wild (02-11) ]
+; { Reason 01 } ; mdrink         [ Magic Drink (Ver 1.2) ]
+; { Reason 01 } ; megat5a        [ Megatouch 5 (9255-60-01 ROC, Standard version) ]
+; { Reason 01 } ; meltyb         [ Melty Blood Act Cadenza Ver B (GDL-0039) ]
+; { Reason 01 } ; meltyba        [ Melty Blood Act Cadenza Ver B (Rev A) (GDL-0039A) ]
+; { Reason 01 } ; meltybld       [ Melty Blood Act Cadenza Ver A (Rev C) (GDL-0028C) ]
+; { Reason 01 } ; metalmx        [ Metal Maniax (prototype) ]
+; { Reason 01 } ; mfightc        [ Mahjong Fight Club (ver JAD) ]
+; { Reason 01 } ; mfightcc       [ Mahjong Fight Club (ver JAC) ]
+; { Reason 01 } ; mgfx           [ Man Guan Fu Xing ]
+; { Reason 01 } ; micrombc       [ Microman Battle Charge (J 990326 V1.000) ]
+; { Reason 01 } ; millsun        [ Millennium Sun ]
+; { Reason 01 } ; miniboy7       [ Mini Boy 7 ]
+; { Reason 01 } ; mirderby       [ Miracle Derby - Ascot ]
+; { Reason 01 } ; mj2            [ Sega Network Taisen Mahjong MJ 2 (Rev C) (GDX-0006C) ]
+; { Reason 01 } ; mj3            [ Sega Network Taisen Mahjong MJ 3 (Rev D) (GDX-0017D) ]
+; { Reason 01 } ; mjsenka        [ Mahjong Senka (Japan) ]
+; { Reason 01 } ; mjsiyoub       [ Mahjong Shiyou (Japan) ]
+; { Reason 01 } ; mjvegas        [ Mahjong Vegas (Japan) ]
+; { Reason 01 } ; mjyarou        [ Mahjong Yarou [BET] (Japan) ]
+; { Reason 01 } ; mlanding       [ Midnight Landing (Germany) ]
+; { Reason 01 } ; mnumber        [ Mystery Number ]
+; { Reason 01 } ; mnumitg        [ Magic Number (Italian Gambling Game, Ver 1.5) ]
+; { Reason 01 } ; mocapb         [ Mocap Boxing (ver AAA) ]
+; { Reason 01 } ; mocapbj        [ Mocap Boxing (ver JAA) ]
+; { Reason 01 } ; mocapglf       [ Mocap Golf (ver UAA) ]
+; { Reason 01 } ; modelr         [ unknown Model Racing gun game ]
+; { Reason 01 } ; moeru          [ Moeru Casinyo (GDL-0013) ]
+; { Reason 01 } ; mok            [ The Maze of the Kings (GDS-0022) ]
+; { Reason 01 } ; mongolnw       [ Mongolfier New (Italian) ]
+; { Reason 01 } ; monsterz       [ Monster Zero ]
+; { Reason 01 } ; monzagp        [ Monza GP ]
+; { Reason 01 } ; mquake         [ Moonquake ]
+; { Reason 01 } ; mrdrilr2       [ Mr. Driller 2 (Japan, DR21 Ver.A) ]
+; { Reason 01 } ; mrdrilrg       [ Mr. Driller G (Japan, DRG1 Ver.A) ]
+; { Reason 01 } ; mrdrlr2a       [ Mr. Driller 2 (Japan, DR22 Ver.A) ]
+; { Reason 01 } ; mrkicker       [ Mr. Kicker ]
+; { Reason 01 } ; mtetrisc       [ Magical Tetris Challenge (981009 Japan) ]
+; { Reason 01 } ; mtonic         [ Magical Odds (set 3, alt hardware) ]
+; { Reason 01 } ; mt_asyn        [ Alien Syndrome (Mega-Tech, SMS based) ]
+; { Reason 01 } ; mt_bbros       [ Bonanza Bros. (Mega-Tech) ]
+; { Reason 01 } ; mt_fwrld       [ Forgotten Worlds (Mega-Tech) ]
+; { Reason 01 } ; mt_gfoot       [ Great Football (Mega-Tech, SMS based) ]
+; { Reason 01 } ; mt_ggolf       [ Great Golf (Mega-Tech, SMS based) ]
+; { Reason 01 } ; mt_gsocr       [ Great Soccer (Mega-Tech, SMS based) ]
+; { Reason 01 } ; multiwin       [ Multi Win (Ver.0167, encrypted) ]
+; { Reason 01 } ; mvsc2          [ Marvel vs. Capcom 2 (JPN, USA, EUR, ASI, AUS) (Rev A) ]
+; { Reason 01 } ; m_bfocus       [ Focus (Dutch, Game Card 95-750-347) ]
+; { Reason 01 } ; m_brkfst       [ The Big Breakfast (Set 1 UK, Game Card 95-750-524) ]
+; { Reason 01 } ; m_ccelbr       [ Club Celebration ]
+; { Reason 01 } ; m_clattr       [ Club attraction (UK, Game Card 39-370-196) ]
+; { Reason 01 } ; m_cpeno1       [ Club Public Enemy No.1 (UK, Game Card 95-750-846) ]
+; { Reason 01 } ; m_gmball       [ Gamball ]
+; { Reason 01 } ; m_honmon       [ Honey Money ]
+; { Reason 01 } ; m_lotsse       [ Lotus SE (Dutch) ]
+; { Reason 01 } ; m_luvjub       [ Luvvly Jubbly (UK Multisite 10/25p, Game Card 95-750-808) ]
+; { Reason 01 } ; m_oldtmr       [ Old Timer ]
+; { Reason 01 } ; m_sptlgt       [ Spotlight ]
+; { Reason 01 } ; m_supcrd       [ Supercards (Dutch, Game Card 39-340-271?) ]
+; { Reason 01 } ; nbajamex       [ NBA Jam Extreme ]
+; { Reason 01 } ; nbanfl         [ NBA Showtime / NFL Blitz 2000 ]
+; { Reason 01 } ; nbashowt       [ NBA Showtime: NBA on NBC ]
+; { Reason 01 } ; nclubv3        [ Name Club Ver.3 (J 970723 V1.000) ]
+; { Reason 01 } ; neptunp2       [ Neptune's Pearls 2 ]
+; { Reason 01 } ; netchu02       [ Netchuu Pro Yakyuu 2002 (NPY1 Ver. A) ]
+; { Reason 01 } ; nflfoot        [ NFL Football ]
+; { Reason 01 } ; nfm            [ New Fruit Machine (Ming-Yang Electronic) ]
+; { Reason 01 } ; ngalsumr       [ Night Gal Summer ]
+; { Reason 01 } ; ngbc           [ Neo-Geo Battle Coliseum ]
+; { Reason 01 } ; nightrai       [ Night Raid (V2.03J) ]
+; { Reason 01 } ; nndmseal       [ Nandemo Seal Iinkai ]
+; { Reason 01 } ; ntcash         [ NtCash ]
+; { Reason 01 } ; nzerotea       [ New Zero Team ]
+; { Reason 01 } ; oceanhun       [ The Ocean Hunter ]
+; { Reason 01 } ; officeye       [ Office Yeo In Cheon Ha (version 1.2) ]
+; { Reason 01 } ; ollie          [ Ollie King (GDX-0007) ]
+; { Reason 01 } ; optiger        [ Operation Tiger ]
+; { Reason 01 } ; otrigger       [ OutTrigger (JPN, USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; outr2          [ Out Run 2 (Rev. A) (GDX-0004A) ]
+; { Reason 01 } ; overrev        [ Over Rev (Revision A) ]
+; { Reason 01 } ; p911           [ Police 911 (ver UAD) ]
+; { Reason 01 } ; p9112          [ Police 911 2 (ver A) ]
+; { Reason 01 } ; p911e          [ Police 24/7 (ver EAA) ]
+; { Reason 01 } ; p911j          [ Keisatsukan Shinjuku 24ji (ver JAC) ]
+; { Reason 01 } ; p911kc         [ Police 911 (ver KAC) ]
+; { Reason 01 } ; p911uc         [ Police 911 (ver UAC) ]
+; { Reason 01 } ; pachifev       [ Pachifever ]
+; { Reason 01 } ; pangofun       [ Pango Fun (Italy) ]
+; { Reason 01 } ; panicprk       [ Panic Park (PNP2 Ver. A) ]
+; { Reason 01 } ; pclub2         [ Print Club 2 (U 970921 V1.000) ]
+; { Reason 01 } ; pclub2v3       [ Print Club 2 Vol. 3 (U 990310 V1.000) ]
+; { Reason 01 } ; pclubj         [ Print Club (Japan Vol.1) ]
+; { Reason 01 } ; pclubjv2       [ Print Club (Japan Vol.2) ]
+; { Reason 01 } ; pclubjv4       [ Print Club (Japan Vol.4) ]
+; { Reason 01 } ; pclubjv5       [ Print Club (Japan Vol.5) ]
+; { Reason 01 } ; pclubpok       [ Print Club Pokemon B (U 991126 V1.000) ]
+; { Reason 01 } ; pf2012         [ Psychic Force 2012 ]
+; { Reason 01 } ; phantomp       [ Phantom Pays - 4VXFC5431 (New Zealand) ]
+; { Reason 01 } ; pharrier       [ Planet Harriers ]
+; { Reason 01 } ; photoply       [ PhotoPlay ]
+; { Reason 01 } ; pinkiri8       [ Pinkiri 8 ]
+; { Reason 01 } ; pirati         [ Pirati ]
+; { Reason 01 } ; pjustic        [ Moero Justice Gakuen (JPN) / Project Justice (USA, EXP, KOR, AUS) (Rev A) ]
+; { Reason 01 } ; plygonet       [ Polygonet Commanders (ver UAA) ]
+; { Reason 01 } ; pmroulet       [ Croupier (Playmark Roulette) ]
+; { Reason 01 } ; podrace        [ Star Wars Pod Racer ]
+; { Reason 01 } ; poizone        [ Poizone ]
+; { Reason 01 } ; poker72        [ Poker Monarch (v2.50) ]
+; { Reason 01 } ; polynetw       [ Poly-Net Warriors (ver JAA) ]
+; { Reason 01 } ; polystar       [ Tobe! Polystars (ver JAA) ]
+; { Reason 01 } ; popn5          [ Pop n' Music 5 ]
+; { Reason 01 } ; popn9          [ Pop'n Music 9 (ver JAB) ]
+; { Reason 01 } ; ppp            [ ParaParaParadise ]
+; { Reason 01 } ; ppp2nd         [ ParaParaParadise 2nd Mix ]
+; { Reason 01 } ; primrag2       [ Primal Rage 2 (Ver 0.36a) ]
+; { Reason 01 } ; prizeinv       [ Prize Space Invaders (20 ]
+; { Reason 01 } ; psattack       [ P's Attack ]
+; { Reason 01 } ; pss62          [ New Super 3D Golf Simulation - Waialae No Kiseki / Super Mahjong 2 (Super Famicom Box) ]
+; { Reason 01 } ; pstone         [ Power Stone (JPN, USA, EUR, ASI, AUS) ]
+; { Reason 01 } ; pstone2        [ Power Stone 2 (JPN, USA, EUR, ASI, AUS) ]
+; { Reason 01 } ; psyvar2        [ Psyvariar 2 - The Will To Fabricate (GDL-0024) ]
+; { Reason 01 } ; puyofev        [ Puyo Puyo Fever (GDS-0031) ]
+; { Reason 01 } ; puzzlet        [ Puzzlet (Japan) ]
+; { Reason 01 } ; puzzli2        [ Puzzli 2 Super (ver. 200) ]
+; { Reason 01 } ; py2k2          [ Photo Y2K 2 ]
+; { Reason 01 } ; pzlestar       [ Puzzle Star (Sang Ho Soft) ]
+; { Reason 01 } ; qmegamis       [ Quiz Ah Megamisama (JPN, USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; qotn           [ Queen of the Nile (B - 13-05-97, NSW/ACT) ]
+; { Reason 01 } ; quake          [ Quake Arcade Tournament (Release Beta 2) ]
+; { Reason 01 } ; quaquiz2       [ Quadro Quiz II ]
+; { Reason 01 } ; quarterh       [ Quarter Horse (set 1, Pioneer PR-8210) ]
+; { Reason 01 } ; quarterha      [ Quarter Horse (set 2, Pioneer PR-8210) ]
+; { Reason 01 } ; quarterhb      [ Quarter Horse (set 3, Pioneer LD-V2000) ]
+; { Reason 01 } ; queen          [ Queen? ]
+; { Reason 01 } ; quickjac       [ Quick Jack ]
+; { Reason 01 } ; quidgrid       [ Ten Quid Grid (v1.2) ]
+; { Reason 01 } ; quidgrid2      [ Ten Quid Grid (v2.4) ]
+; { Reason 01 } ; quidgrid2d     [ Ten Quid Grid (v2.4, Datapak) ]
+; { Reason 01 } ; quidgridd      [ Ten Quid Grid (v1.2, Datapak) ]
+; { Reason 01 } ; quintond       [ Quintoon (UK, Game Card 95-751-206, Datapak) ]
+; { Reason 01 } ; quizard        [ Quizard 1.7 ]
+; { Reason 01 } ; quizmstr       [ Quizmaster (German) ]
+; { Reason 01 } ; quizpun2       [ Quiz Punch 2 ]
+; { Reason 01 } ; quizqgd        [ Quiz Keitai Q mode (GDL-0017) ]
+; { Reason 01 } ; quizrd22       [ Quizard 2.2 ]
+; { Reason 01 } ; quizrd32       [ Quizard 3.2 ]
+; { Reason 01 } ; quizrr41       [ Quizard Rainbow 4.1 ]
+; { Reason 01 } ; r2dx_v33       [ Raiden II / DX (newer V33 PCB) ]
+; { Reason 01 } ; racedrivpan    [ Race Drivin' Panorama (prototype, rev 2.1) ]
+; { Reason 01 } ; racingj        [ Racing Jam ]
+; { Reason 01 } ; racingj2       [ Racing Jam: Chapter 2 ]
+; { Reason 01 } ; radirgy        [ Radirgy (GDL-0032) ]
+; { Reason 01 } ; raidndx        [ Raiden DX (UK) ]
+; { Reason 01 } ; raidndxa1      [ Raiden DX (Asia set 1) ]
+; { Reason 01 } ; raidndxa2      [ Raiden DX (Asia set 2) ]
+; { Reason 01 } ; raidndxg       [ Raiden DX (Germany) ]
+; { Reason 01 } ; raidndxj       [ Raiden DX (Japan) ]
+; { Reason 01 } ; raidndxu       [ Raiden DX (US) ]
+; { Reason 01 } ; rangrmsn       [ Ranger Mission ]
+; { Reason 01 } ; rapidrvr       [ Rapid River (RD3 Ver. C) ]
+; { Reason 01 } ; rapidrvr2      [ Rapid River (RD2 Ver. C) ]
+; { Reason 01 } ; rblaster       [ Road Blaster (Data East LD) ]
+; { Reason 01 } ; rcdego         [ RC De Go (V2.03J) ]
+; { Reason 01 } ; rchase2        [ Rail Chase 2 (Revision A) ]
+; { Reason 01 } ; rcorsair       [ Red Corsair ]
+; { Reason 01 } ; rebus          [ Rebus ]
+; { Reason 01 } ; revenger       [ Revenger ]
+; { Reason 01 } ; rgum           [ Royal Gum (Italy) ]
+; { Reason 01 } ; ridgera2       [ Ridge Racer 2 (Rev. RRS2, US) ]
+; { Reason 01 } ; ridgera2j      [ Ridge Racer 2 (Rev. RRS1, Ver.B, Japan) ]
+; { Reason 01 } ; ridgera2ja     [ Ridge Racer 2 (Rev. RRS1, Japan) ]
+; { Reason 01 } ; roadburn       [ Road Burners ]
+; { Reason 01 } ; roadedge       [ Roads Edge / Round Trip (rev.B) ]
+; { Reason 01 } ; ronjan         [ Ron Jan (Super) ]
+; { Reason 01 } ; royalqn        [ Royal Queen [BET] (Japan 841010 RQ 0-07) ]
+; { Reason 01 } ; rungun2        [ Run and Gun 2 (ver UAA) ]
+; { Reason 01 } ; rushhero       [ Rushing Heroes (ver UAB) ]
+; { Reason 01 } ; salmankt       [ Salary Man Kintarou ]
+; { Reason 01 } ; saloon         [ Saloon (French, encrypted) ]
+; { Reason 01 } ; samba          [ Samba De Amigo (JPN) (Rev B) ]
+; { Reason 01 } ; sams64         [ Samurai Shodown 64 / Samurai Spirits 64 ]
+; { Reason 01 } ; sams64_2       [ Samurai Shodown: Warrior's Rage / Samurai Spirits 2: Asura Zanmaden ]
+; { Reason 01 } ; scg06nt        [ Sega Club Golf 2006 Next Tours (Rev A) (GDX-0018A) ]
+; { Reason 01 } ; schamp         [ Sonic Championship ]
+; { Reason 01 } ; screenp1       [ Screen Play (ver. 1.9) ]
+; { Reason 01 } ; screenp2       [ Screen Play (ver. 1.9, Isle of Man) ]
+; { Reason 01 } ; screenpl       [ Screen Play (ver. 4.0) ]
+; { Reason 01 } ; scudj          [ Scud Race (Japan) ]
+; { Reason 01 } ; sddz           [ Super Dou Di Zhu ]
+; { Reason 01 } ; sdwx           [ Sheng Dan Wu Xian ]
+; { Reason 01 } ; segawski       [ Sega Water Ski (Japan, Revision A) ]
+; { Reason 01 } ; senko          [ Senko No Ronde NEW ver. (Rev A) (GDL-0030A) ]
+; { Reason 01 } ; senkoo         [ Senko No Ronde (GDL-0030) ]
+; { Reason 01 } ; senkosp        [ Senko No Ronde Special (GDL-0038) ]
+; { Reason 01 } ; sf2049         [ San Francisco Rush 2049 ]
+; { Reason 01 } ; sf2049se       [ San Francisco Rush 2049: Special Edition ]
+; { Reason 01 } ; sf2049te       [ San Francisco Rush 2049: Tournament Edition ]
+; { Reason 01 } ; sfight         [ Sonic The Fighters ]
+; { Reason 01 } ; sfish2         [ Sport Fishing 2 (UET 951106 V1.10e) ]
+; { Reason 01 } ; sfish2j        [ Sport Fishing 2 (J 951201 V1.100) ]
+; { Reason 01 } ; sfz3ugd        [ Street Fighter Zero 3 Upper (GDL-0002) ]
+; { Reason 01 } ; sgt24h         [ Super GT 24h ]
+; { Reason 01 } ; sgtetris       [ Sega Tetris ]
+; { Reason 01 } ; shadfgtr       [ Shadow Fighters ]
+; { Reason 01 } ; shangril       [ Dengen Tenshi Taisen Janshi Shangri-la (JPN, USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; sharkpy        [ Shark Party (Italy, v1.3) ]
+; { Reason 01 } ; sharkpya       [ Shark Party (Italy, v1.6) ]
+; { Reason 01 } ; shikgam2       [ Shikigami No Shiro II / The Castle of Shikigami II (GDL-0021) ]
+; { Reason 01 } ; shootopl       [ Shootout Pool ]
+; { Reason 01 } ; shootpl        [ Shootout Pool (JPN, USA, KOR, AUS) / Shootout Pool Prize (EXP) ]
+; { Reason 01 } ; skattv         [ Skat TV ]
+; { Reason 01 } ; skattva        [ Skat TV (version TS3) ]
+; { Reason 01 } ; skeetsht       [ Skeet Shot ]
+; { Reason 01 } ; skichamp       [ Ski Champ ]
+; { Reason 01 } ; skiltrek       [ Skill Trek (v1.1) ]
+; { Reason 01 } ; skimaxx        [ Skimaxx ]
+; { Reason 01 } ; skisuprg       [ Sega Ski Super G ]
+; { Reason 01 } ; skytargt       [ Sky Target ]
+; { Reason 01 } ; slamdnk2       [ Slam Dunk 2 (ver JAA) ]
+; { Reason 01 } ; slasho         [ Slashout (JPN, USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; slashout       [ Slashout (GDS-0004) ]
+; { Reason 01 } ; smarinef       [ Sega Marine Fishing ]
+; { Reason 01 } ; smlg99         [ Super Major League '99 ]
+; { Reason 01 } ; smoto16        [ Super Moto (Italy, v1.6) ]
+; { Reason 01 } ; smoto20        [ Super Rider (Italy, v2.0) ]
+; { Reason 01 } ; smshilo        [ HI-LO Double Up Joker Poker ]
+; { Reason 01 } ; soccernw       [ Soccer New (Italian) ]
+; { Reason 01 } ; soccerss       [ Soccer Superstars (ver EAA) ]
+; { Reason 01 } ; soccerssa      [ Soccer Superstars (ver AAA) ]
+; { Reason 01 } ; soccerssj      [ Soccer Superstars (ver JAC) ]
+; { Reason 01 } ; soccerssja     [ Soccer Superstars (ver JAA) ]
+; { Reason 01 } ; sogeki         [ Sogeki (ver JAA) ]
+; { Reason 01 } ; soulcl2a       [ Soul Calibur II (SC21 Ver. A) ]
+; { Reason 01 } ; soulclb2       [ Soul Calibur II (SC23 Ver. A) ]
+; { Reason 01 } ; soulclb3       [ Soul Calibur III (SC31001-NA-A) ]
+; { Reason 01 } ; sparkman       [ Spark Man (v 2.0, set 1) ]
+; { Reason 01 } ; sparkmana      [ Spark Man (v 2.0, set 2) ]
+; { Reason 01 } ; spawn          [ Spawn (JPN, USA, EUR, ASI, AUS) ]
+; { Reason 01 } ; spikeofe       [ Spikeout Final Edition ]
+; { Reason 01 } ; spikeout       [ Spikeout (Revision C) ]
+; { Reason 01 } ; spkrbtl        [ Spikers Battle (GDS-0005) ]
+; { Reason 01 } ; sprtjam        [ Sports Jam (GDS-0003) ]
+; { Reason 01 } ; sprtshot       [ Sports Shooting USA ]
+; { Reason 01 } ; srally2        [ Sega Rally 2 ]
+; { Reason 01 } ; srally2x       [ Sega Rally 2 DX ]
+; { Reason 01 } ; srallyc        [ Sega Rally Championship ]
+; { Reason 01 } ; srmvs          [ Super Real Mahjong VS ]
+; { Reason 01 } ; ss2005         [ Super Shanghai 2005 (GDL-0031) ]
+; { Reason 01 } ; ss2005a        [ Super Shanghai 2005 (Rev A) (GDL-0031A) ]
+; { Reason 01 } ; sscope         [ Silent Scope (ver JZD) ]
+; { Reason 01 } ; sscope2        [ Silent Scope 2 ]
+; { Reason 01 } ; sscopex        [ Silent Scope EX (ver UAA) ]
+; { Reason 01 } ; sspac2k1       [ Super Space 2001 ]
+; { Reason 01 } ; sstar          [ Super Star ]
+; { Reason 01 } ; sstrkfgt       [ Sega Strike Fighter (Rev A) ]
+; { Reason 01 } ; stadhr96       [ Stadium Hero 96 (World, EAJ) ]
+; { Reason 01 } ; stadhr96j      [ Stadium Hero 96 (Japan, EAD) ]
+; { Reason 01 } ; starspnr       [ Starspinner (Dutch/Nederlands) ]
+; { Reason 01 } ; startrgn       [ Star Trigon (Japan, STT1 Ver.A) ]
+; { Reason 01 } ; starzan        [ Super Tarzan (Italy, V100I) ]
+; { Reason 01 } ; stcc           [ Sega Touring Car Championship (Revision A) ]
+; { Reason 01 } ; steaser        [ Strip Teaser (Italy, Version 1.22) ]
+; { Reason 01 } ; stellecu       [ Stelle e Cubi (Italy) ]
+; { Reason 01 } ; step3          [ Stepping 3 Superior ]
+; { Reason 01 } ; stepstag       [ Stepping Stage Special ]
+; { Reason 01 } ; streetg        [ Street Games (Revision 4) ]
+; { Reason 01 } ; streetg2       [ Street Games II (Revision 7C) ]
+; { Reason 01 } ; streetg2r5     [ Street Games II (Revision 5) ]
+; { Reason 01 } ; streetgr3      [ Street Games (Revision 3) ]
+; { Reason 01 } ; stress         [ Stress Busters (J 981020 V1.000) ]
+; { Reason 01 } ; strikeit       [ Strike it Lucky (v0.5) ]
+; { Reason 01 } ; strikeit2      [ Strike it Lucky (v0.53) ]
+; { Reason 01 } ; strikeit2d     [ Strike it Lucky (v0.53, Datapak) ]
+; { Reason 01 } ; strikeitd      [ Strike it Lucky (v0.5, Datapak) ]
+; { Reason 01 } ; suchie3        [ Idol Janshi Suchie-Pai 3 (JPN) ]
+; { Reason 01 } ; sukuinuf       [ Quiz and Variety Suku Suku Inufuku 2 (IN2 Ver. A) ]
+; { Reason 01 } ; supjolly       [ Super Jolly ]
+; { Reason 01 } ; supnudg2       [ Super Nudger II (Version 5.21) ]
+; { Reason 01 } ; suprpool       [ Super Pool (9743 rev.01) ]
+; { Reason 01 } ; sws2000        [ Super World Stadium 2000 (Japan, SS01/VER.A) ]
+; { Reason 01 } ; sws2001        [ Super World Stadium 2001 (Japan, SS11/VER.A) ]
+; { Reason 01 } ; swthrt2v       [ Sweet Hearts II (C - 07/09/95, Venezuela version) ]
+; { Reason 01 } ; swtht2nz       [ Sweet Hearts II - 1VXFC5461 (New Zealand) ]
+; { Reason 01 } ; taiko10        [ Taiko No Tatsujin 10 (T101001-NA-A) ]
+; { Reason 01 } ; taiko9         [ Taiko No Tatsujin 9 (TK91001-NA-A) ]
+; { Reason 01 } ; takoron        [ Noukone Puzzle Takoron (GDL-0042) ]
+; { Reason 01 } ; tankbatl       [ Tank Battle (prototype rev. 4/21/92) ]
+; { Reason 01 } ; targeth        [ Target Hits (ver 1.1) ]
+; { Reason 01 } ; tarzan         [ Tarzan (V109C) ]
+; { Reason 01 } ; tarzana        [ Tarzan (V107) ]
+; { Reason 01 } ; tattack        [ Time Attacker ]
+; { Reason 01 } ; tcl            [ Taiwan Chess Legend ]
+; { Reason 01 } ; te0144         [ Puzzle Bobble (Italian Gambling Game) ]
+; { Reason 01 } ; techbowl       [ Technical Bowling (J 971212 V1.000) ]
+; { Reason 01 } ; tekken4        [ Tekken 4 (TEF3 Ver. C) ]
+; { Reason 01 } ; tekken4a       [ Tekken 4 (TEF2 Ver. A) ]
+; { Reason 01 } ; tekken4b       [ Tekken 4 (TEF1 Ver. A) ]
+; { Reason 01 } ; tekken51       [ Tekken 5.1 (TE51 Ver. B) ]
+; { Reason 01 } ; tenpindx       [ Ten Pin Deluxe ]
+; { Reason 01 } ; terabrst       [ Teraburst (1998/07/17 ver UEL) ]
+; { Reason 01 } ; terabrsta      [ Teraburst (1998/02/25 ver AAA) ]
+; { Reason 01 } ; tetkiwam       [ Tetris Kiwamemichi (GDL-0020) ]
+; { Reason 01 } ; tgtpanic       [ Target Panic ]
+; { Reason 01 } ; theglad        [ The Gladiator (ver. 100) ]
+; { Reason 01 } ; theglada       [ The Gladiator (ver. 101) ]
+; { Reason 01 } ; thegrid        [ The Grid (version 1.2) ]
+; { Reason 01 } ; thegrida       [ The Grid (version 1.1) ]
+; { Reason 01 } ; thoop2         [ TH Strikes Back ]
+; { Reason 01 } ; thrild2        [ Thrill Drive 2 (ver EBB) ]
+; { Reason 01 } ; thrild2a       [ Thrill Drive 2 (ver AAA) ]
+; { Reason 01 } ; thrild2c       [ Thrill Drive 2 (ver EAA) ]
+; { Reason 01 } ; thrilld        [ Thrill Drive (JAE) ]
+; { Reason 01 } ; thrilldb       [ Thrill Drive (JAB) ]
+; { Reason 01 } ; thunderh       [ Operation Thunder Hurricane (ver EAA) ]
+; { Reason 01 } ; timecrs2       [ Time Crisis 2 (TSS3 Ver. B) ]
+; { Reason 01 } ; timecrs2b      [ Time Crisis 2 (TSS2 Ver. B) ]
+; { Reason 01 } ; timecrs2c      [ Time Crisis 2 (TSS4 Ver. A) ]
+; { Reason 01 } ; timecrs3       [ Time Crisis 3 (TST1) ]
+; { Reason 01 } ; timemchn       [ Time Machine (v2.0) ]
+; { Reason 01 } ; timetrv        [ Time Traveler ]
+; { Reason 01 } ; tisland        [ Treasure Island ]
+; { Reason 01 } ; tmek44         [ T-MEK (v4.4) ]
+; { Reason 01 } ; tmek45         [ T-MEK (v4.5) ]
+; { Reason 01 } ; tmek51p        [ T-MEK (v5.1, prototype) ]
+; { Reason 01 } ; tokyocop       [ Tokyo Cop (Italy) ]
+; { Reason 01 } ; tokyowar       [ Tokyo Wars (Rev. TW2 Ver.A) ]
+; { Reason 01 } ; topbladv       [ Top Blade V ]
+; { Reason 01 } ; topgear        [ Top Gear - 4VXFC969 ]
+; { Reason 01 } ; topshoot       [ Top Shooter ]
+; { Reason 01 } ; topskatr       [ Top Skater (Export, Revision A) ]
+; { Reason 01 } ; topskatru      [ Top Skater (USA) ]
+; { Reason 01 } ; tornado2       [ Tornado (bootleg set 2) ]
+; { Reason 01 } ; totd           [ The Typing of the Dead (JPN, USA, EXP, KOR, AUS) (Rev A) ]
+; { Reason 01 } ; totlvice       [ Total Vice (ver UAC) ]
+; { Reason 01 } ; totlvicj       [ Total Vice (ver JAD) ]
+; { Reason 01 } ; touchgo        [ Touch & Go (World) ]
+; { Reason 01 } ; touchgoe       [ Touch & Go (earlier revision) ]
+; { Reason 01 } ; touchgon       [ Touch & Go (Non North America) ]
+; { Reason 01 } ; toukon3        [ Shin Nihon Pro Wrestling Toukon Retsuden 3 Arcade Edition (Japan, TR1/VER.A) ]
+; { Reason 01 } ; toursol        [ Tournament Solitaire (V1.06, 08/03/95) ]
+; { Reason 01 } ; toursol1       [ Tournament Solitaire (V1.04, 06/22/95) ]
+; { Reason 01 } ; toyfight       [ Toy Fighter ]
+; { Reason 01 } ; trackfldnz     [ Track & Field (NZ bootleg?) ]
+; { Reason 01 } ; trailblz       [ Trail Blazer ]
+; { Reason 01 } ; trgheart       [ Trigger Heart Exelica (Rev A) (GDL-0036A) ]
+; { Reason 01 } ; tripdraw       [ Tripple Draw (V3.1 s) ]
+; { Reason 01 } ; trizeal        [ Trizeal (GDL-0026) ]
+; { Reason 01 } ; trstar2k       [ Triple Star 2000 ]
+; { Reason 01 } ; trvchlng       [ Trivia Challenge ]
+; { Reason 01 } ; trvhanga       [ Trivia Hangup (Question Set 2) ]
+; { Reason 01 } ; trvmadns       [ Trivia Madness ]
+; { Reason 01 } ; tsurugi        [ Tsurugi (ver EAB) ]
+; { Reason 01 } ; tsurugij       [ Tsurugi (ver JAC) ]
+; { Reason 01 } ; ttchamp        [ Table Tennis Champions (set 1) ]
+; { Reason 01 } ; ttchampa       [ Table Tennis Champions (set 2) ]
+; { Reason 01 } ; turbosub       [ Turbo Sub (prototype rev. TSCA) ]
+; { Reason 01 } ; turnover       [ Turnover (v2.3) ]
+; { Reason 01 } ; turrett        [ Turret Tower ]
+; { Reason 01 } ; twcup98        [ Tecmo World Cup '98 (JUET 980410 V1.000) ]
+; { Reason 01 } ; twrshaft       [ Tower & Shaft ]
+; { Reason 01 } ; undefeat       [ Under Defeat (GDL-0035) ]
+; { Reason 01 } ; unkch1         [ New Cherry Gold '99 (bootleg of Super Cherry Master) (set 1) ]
+; { Reason 01 } ; unkch2         [ Super Cherry Gold (bootleg of Super Cherry Master) ]
+; { Reason 01 } ; unkch3         [ New Cherry Gold '99 (bootleg of Super Cherry Master) (set 2) ]
+; { Reason 01 } ; unkch4         [ Grand Cherry Master (bootleg of Super Cherry Master) ]
+; { Reason 01 } ; unkmeyco       [ unknown Meyco game ]
+; { Reason 01 } ; usagui         [ Usagi - Yamashiro Mahjong Hen (GDL-0022) ]
+; { Reason 01 } ; vandykeb       [ Vandyke (bootleg with PIC16c57) ]
+; { Reason 01 } ; vathlete       [ Virtua Athletics / Virtua Athlete (GDS-0019) ]
+; { Reason 01 } ; vcombat        [ Virtual Combat ]
+; { Reason 01 } ; vcop           [ Virtua Cop (Revision B) ]
+; { Reason 01 } ; vcop2          [ Virtua Cop 2 ]
+; { Reason 01 } ; vcop3          [ Virtua Cop 3 (GDX-0003A) ]
+; { Reason 01 } ; vega           [ Vega ]
+; { Reason 01 } ; version4       [ Version 4 (Version 4.2R) ]
+; { Reason 01 } ; vf2a           [ Virtua Fighter 2 (Revision A) ]
+; { Reason 01 } ; vf3            [ Virtua Fighter 3 (Revision C) ]
+; { Reason 01 } ; vf3a           [ Virtua Fighter 3 (Revision A) ]
+; { Reason 01 } ; vf3tb          [ Virtua Fighter 3 Team Battle ]
+; { Reason 01 } ; vf4            [ Virtua Fighter 4 (GDS-0012) ]
+; { Reason 01 } ; vf4b           [ Virtua Fighter 4 (Rev B) (GDS-0012B) ]
+; { Reason 01 } ; vf4c           [ Virtua Fighter 4 (Rev C) (GDS-0012C) ]
+; { Reason 01 } ; vf4evo         [ Virtua Fighter 4 Evolution (Rev B) (GDS-0024B) ]
+; { Reason 01 } ; vf4evoa        [ Virtua Fighter 4 Evolution (Rev A) (GDS-0024A) ]
+; { Reason 01 } ; vf4evoct       [ Virtua Fighter 4 Evolution (Cartridge) ]
+; { Reason 01 } ; vf4tuned       [ Virtua Fighter 4 Final Tuned (Rev F) (GDS-0036F) ]
+; { Reason 01 } ; vf4tuneda      [ Virtua Fighter 4 Final Tuned (Rev A) (GDS-0036A) ]
+; { Reason 01 } ; vf4tunedd      [ Virtua Fighter 4 Final Tuned (Rev D) (GDS-0036D) ]
+; { Reason 01 } ; vfurlong       [ Net Select Keiba Victory Furlong ]
+; { Reason 01 } ; vgoalsca       [ V Goal Soccer (set 2) ]
+; { Reason 01 } ; vgoalsoc       [ V Goal Soccer (set 1) ]
+; { Reason 01 } ; vgpoker        [ Vegas Poker (prototype, release 2) ]
+; { Reason 01 } ; victor21       [ Victor 21 ]
+; { Reason 01 } ; videocba       [ Video Cordoba ]
+; { Reason 01 } ; videodad       [ Video Dado ]
+; { Reason 01 } ; videopkr       [ Video Poker ]
+; { Reason 01 } ; virnba         [ Virtua NBA (JPN, USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; virnbao        [ Virtua NBA (JPN, USA, EXP, KOR, AUS) (original) ]
+; { Reason 01 } ; von            [ Virtual On Cyber Troopers (US, Revision B) ]
+; { Reason 01 } ; von2           [ Virtual On 2: Oratorio Tangram (Revision B) ]
+; { Reason 01 } ; von254g        [ Virtual On 2: Oratorio Tangram (ver 5.4g) ]
+; { Reason 01 } ; vonj           [ Virtual On Cyber Troopers (Japan, Revision B) ]
+; { Reason 01 } ; vortex         [ Vortex ]
+; { Reason 01 } ; vpoker         [ Videotronics Poker ]
+; { Reason 01 } ; vs2002ex       [ Virtua Striker 2002 (GDT-0002) ]
+; { Reason 01 } ; vs2002j        [ Virtua Striker 2002 (GDT-0001) ]
+; { Reason 01 } ; vs298          [ Virtua Striker 2 '98 (Step 2.0) ]
+; { Reason 01 } ; vs299          [ Virtua Striker 2 '99 ]
+; { Reason 01 } ; vs299a         [ Virtua Striker 2 '99 (Revision A) ]
+; { Reason 01 } ; vs299b         [ Virtua Striker 2 '99 (Revision B) ]
+; { Reason 01 } ; vs2v991        [ Virtua Striker 2 '99.1 (Revision B) ]
+; { Reason 01 } ; vs2_2k         [ Virtua Striker 2 Ver. 2000 (JPN, USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; vs4            [ Virtua Striker 4 (Export) (GDT-0015) ]
+; { Reason 01 } ; vs42006        [ Virtua Striker 4 ver. 2006 (Rev D) (Japan) (GDT-0020D) ]
+; { Reason 01 } ; vs4j           [ Virtua Striker 4 (Japan) (GDT-0013E) ]
+; { Reason 01 } ; vsnetscr       [ Versus Net Soccer (ver EAD) ]
+; { Reason 01 } ; vsnetscra      [ Versus Net Soccer (ver AAA) ]
+; { Reason 01 } ; vsnetscreb     [ Versus Net Soccer (ver EAB) ]
+; { Reason 01 } ; vsnetscrj      [ Versus Net Soccer (ver JAB) ]
+; { Reason 01 } ; vsnetscru      [ Versus Net Soccer (ver UAB) ]
+; { Reason 01 } ; vspsx          [ Video System PSX ]
+; { Reason 01 } ; vstars         [ Video Stars ]
+; { Reason 01 } ; vstrik3        [ Virtua Striker 3 (GDS-0006) ]
+; { Reason 01 } ; vstrik3c       [ Virtua Striker 3 (Cart) (USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; vstriker       [ Virtua Striker (Revision A) ]
+; { Reason 01 } ; vstrikero      [ Virtua Striker ]
+; { Reason 01 } ; vtenis2c       [ Power Smash 2 / Virtua Tennis 2 (cartridge) ]
+; { Reason 01 } ; vtennis        [ Power Smash (JPN) / Virtua Tennis (USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; vtennis2       [ Virtua Tennis 2 (Rev A) (GDS-0015A) ]
+; { Reason 01 } ; vtennisg       [ Virtua Tennis (GDS-0011) ]
+; { Reason 01 } ; wangmid        [ Wangan Midnight Maximum Tune (Rev. B) (Export) (GDX-0009B) ]
+; { Reason 01 } ; wangmid2       [ Wangan Midnight Maximum Tune 2 (Export) (GDX-0015) ]
+; { Reason 01 } ; warfa          [ War: The Final Assault ]
+; { Reason 01 } ; warofbugg      [ War of the Bugs or Monsterous Manouvers in a Mushroom Maze (German) ]
+; { Reason 01 } ; waverunr       [ Wave Runner (Japan, Revision A) ]
+; { Reason 01 } ; wcat3          [ Wild Cat 3 ]
+; { Reason 01 } ; wcombat        [ World Combat (ver UAA?) ]
+; { Reason 01 } ; wcombatj       [ World Combat (ver JAA) ]
+; { Reason 01 } ; wcombatk       [ World Combat (ver KBC) ]
+; { Reason 01 } ; winbingo       [ Win Win Bingo (set 1) ]
+; { Reason 01 } ; winbingoa      [ Win Win Bingo (set 2) ]
+; { Reason 01 } ; winrun         [ Winning Run Suzuka Grand Prix (Japan) ]
+; { Reason 01 } ; winrun91       [ Winning Run 91 (Japan) ]
+; { Reason 01 } ; wizard         [ Wizard (Ver 1.0) ]
+; { Reason 01 } ; wldrider       [ Wild Riders (JPN, USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; wpksoc         [ World PK Soccer ]
+; { Reason 01 } ; wsbbgd         [ World Series Baseball / Super Major League (GDS-0010) ]
+; { Reason 01 } ; wtigernz       [ White Tiger - 3VXFC5342 (New Zealand) ]
+; { Reason 01 } ; wwfroyal       [ WWF Royal Rumble (JPN, USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; x5jokers       [ X Five Jokers (Version 1.12) ]
+; { Reason 01 } ; xrally         [ Xtreme Rally / Off Beat Racer! ]
+; { Reason 01 } ; xsedae         [ X Se Dae Quiz ]
+; { Reason 01 } ; xtrial         [ Xtrial Racing (ver JAB) ]
+; { Reason 01 } ; xtrmhnt2       [ Extreme Hunting 2 ]
+; { Reason 01 } ; xtrmhunt       [ Extreme Hunting ]
+; { Reason 01 } ; zerogun        [ Zero Gunner (Model 2B) ]
+; { Reason 01 } ; zeroguna       [ Zero Gunner (Model 2A) ]
+; { Reason 01 } ; zerogunj       [ Zero Gunner (Japan Model 2B) ]
+; { Reason 01 } ; zeroteam       [ Zero Team (set 1) ]
+; { Reason 01 } ; zeroteama      [ Zero Team (set 2) ]
+; { Reason 01 } ; zeroteamb      [ Zero Team (set 3) ]
+; { Reason 01 } ; zeroteamc      [ Zero Team (set 4) ]
+; { Reason 01 } ; zeroteams      [ Zero Team Selection ]
+; { Reason 01 } ; zgundm         [ Mobile Suit Z-Gundam: A.E.U.G. vs Titans (ZGA1 Ver. A) ]
+; { Reason 01 } ; zgundmdx       [ Mobile Suit Z-Gundam: A.E.U.G. vs Titans DX (ZDX1 Ver. A) ]
+; { Reason 01 } ; zombrvn        [ Zombie Revenge (JPN, USA, EXP, KOR, AUS) ]
+; { Reason 01 } ; zoo            [ Zoo ]
+; { Reason 02 } ; hanaroku       [ Hanaroku ]
+; { Reason 02 } ; livequiz       [ Live Quiz Show ]
+; { Reason 03 } ; bishjan        [ Bishou Jan (Japan 203) ]
+; { Reason 03 } ; chinsan        [ Ganbare Chinsan Ooshoubu (MC-8123A, 317-5012) ]
+; { Reason 03 } ; daimyojn       [ Mahjong Daimyojin (Japan, T017-PB-00) ]
+; { Reason 03 } ; daireika       [ Mahjong Daireikai (Japan) ]
+; { Reason 03 } ; dakkochn       [ DakkoChan House (MC-8123, 317-0014) ]
+; { Reason 03 } ; dbc            [ Da Ban Cheng (Hong Kong, V027H) ]
+; { Reason 03 } ; ejsakura       [ E-Jan Sakurasou (v2.0) ]
+; { Reason 03 } ; ejsakura12     [ E-Jan Sakurasou (v1.2) ]
+; { Reason 03 } ; finalgdr       [ Final Godori (Korea, version 2.20.5915) ]
+; { Reason 03 } ; gekisha        [ Mahjong Gekisha ]
+; { Reason 03 } ; go2000         [ Go 2000 ]
+; { Reason 03 } ; hanayara       [ Hana wo Yaraneba! (Japan) ]
+; { Reason 03 } ; hginga         [ Hanafuda Hana Ginga ]
+; { Reason 03 } ; hgokou         [ Hanafuda Hana Gokou (Japan) ]
+; { Reason 03 } ; hjingi         [ Hana Jingi (Japan, Bet) ]
+; { Reason 03 } ; hnageman       [ AV Hanafuda Hana no Ageman (Japan 900716) ]
+; { Reason 03 } ; hnxmasev       [ AV Hanafuda Hana no Christmas Eve (Japan 901204) ]
+; { Reason 03 } ; hparadis       [ Super Hana Paradise (Japan) ]
+; { Reason 03 } ; htengoku       [ Hanafuda Hana Tengoku (Japan) ]
+; { Reason 03 } ; ippatsu        [ Ippatsu Gyakuten [BET] (Japan) ]
+; { Reason 03 } ; janoh          [ Jan Oh (set 1) ]
+; { Reason 03 } ; janoha         [ Jan Oh (set 2) ]
+; { Reason 03 } ; janputer       [ New Double Bet Mahjong (Japan) ]
+; { Reason 03 } ; jansoua        [ Jansou (set 2) ]
+; { Reason 03 } ; jantotsu       [ 4nin-uchi Mahjong Jantotsu ]
+; { Reason 03 } ; janyoup2       [ Janyou Part II (ver 7.03, July 1 1983) ]
+; { Reason 03 } ; jongtei        [ Mahjong Jong-Tei (Japan, ver. NM532-01) ]
+; { Reason 03 } ; kisekaeh       [ Kisekae Hanafuda ]
+; { Reason 03 } ; koikoi         [ Koi Koi Part 2 ]
+; { Reason 03 } ; lhzb2          [ Mahjong Long Hu Zheng Ba 2 (set 1) ]
+; { Reason 03 } ; lhzb2a         [ Mahjong Long Hu Zheng Ba 2 (set 2) ]
+; { Reason 03 } ; lovehous       [ Mahjong Love House [BET] (Japan 901024) ]
+; { Reason 03 } ; lvpoker        [ Lovely Poker [BET] ]
+; { Reason 03 } ; mahjngoh       [ Mahjong Oh (V2.06J) ]
+; { Reason 03 } ; majrjhdx       [ Mahjong Raijinhai DX ]
+; { Reason 03 } ; mgcs           [ Mahjong Man Guan Cai Shen (V103CS) ]
+; { Reason 03 } ; mgdh           [ Mahjong Man Guan Da Heng (Taiwan, V123T1) ]
+; { Reason 03 } ; mgion          [ Gionbana [BET] (Japan 890207) ]
+; { Reason 03 } ; mirage         [ Mirage Youjuu Mahjongden (Japan) ]
+; { Reason 03 } ; mjclub         [ Mahjong Club [BET] (Japan) ]
+; { Reason 03 } ; mjgaiden       [ Mahjong Gaiden [BET] (Japan 870803) ]
+; { Reason 03 } ; mjprivat       [ Mahjong Private (Japan) ]
+; { Reason 03 } ; mjvegasa       [ Mahjong Vegas (Japan, unprotected) ]
+; { Reason 03 } ; mmaiko         [ Maikobana [BET] (Japan 900911) ]
+; { Reason 03 } ; musobana       [ Musoubana (Japan) ]
+; { Reason 03 } ; myfairld       [ Virtual Mahjong 2 - My Fair Lady (J 980608 V1.000) ]
+; { Reason 03 } ; ngtbunny       [ Night Bunny (Japan 840601 MRN 2-10) ]
+; { Reason 03 } ; nightgal       [ Night Gal (Japan 840920 AG 1-00) ]
+; { Reason 03 } ; nkishusp       [ Mahjong Nenrikishu SP ]
+; { Reason 03 } ; ohpaipee       [ Oh! Paipee (Japan 890227) ]
+; { Reason 03 } ; openmj         [ Open Mahjong [BET] (Japan) ]
+; { Reason 03 } ; ptrmj          [ PT Reach Mahjong (Japan) ]
+; { Reason 03 } ; rbmk           [ Real Battle Mahjong King ]
+; { Reason 03 } ; royalmj        [ Royal Mahjong (Japan, v1.13) ]
+; { Reason 03 } ; ryukobou       [ Mahjong Ryukobou (Japan, V030J) ]
+; { Reason 03 } ; sdmg2          [ Mahjong Super Da Man Guan II (China, V754C) ]
+; { Reason 03 } ; sexygal        [ Sexy Gal (Japan 850501 SXG 1-00) ]
+; { Reason 03 } ; slqz2          [ Mahjong Shuang Long Qiang Zhu 2 ]
+; { Reason 03 } ; srmp5          [ Super Real Mahjong P5 ]
+; { Reason 03 } ; sryudens       [ Mahjong Seiryu Densetsu (Japan, NM502) ]
+; { Reason 03 } ; sweetgal       [ Sweet Gal (Japan 850510 SWG 1-02) ]
+; { Reason 03 } ; tjsb           [ Mahjong Tian Jiang Shen Bing ]
+; { Reason 03 } ; tmpdoki        [ Tokimeki Mahjong Paradise - Doki Doki Hen ]
+; { Reason 03 } ; togenkyo       [ Tougenkyou (Japan 890418) ]
+; { Reason 03 } ; urashima       [ Otogizoushi Urashima Mahjong (Japan) ]
+; { Reason 03 } ; usagi          [ Usagi (V2.02J) ]
+; { Reason 03 } ; yumefuda       [ (Medal) Yumefuda [BET] ]
+; { Reason 05 } ; aquajet        [ Aqua Jet (Rev. AJ2 Ver.B) ]
+; { Reason 05 } ; bmiidx4        [ beatmania IIDX 4th style (GCA03 JA) ]
+; { Reason 05 } ; bmiidx6        [ beatmania IIDX 6th style (GCB4U JA) ]
+; { Reason 05 } ; bmiidx7        [ beatmania IIDX 7th style (GCB44 JA) ]
+; { Reason 05 } ; bmiidx8        [ beatmania IIDX 8th style (GCC44 JA) ]
+; { Reason 05 } ; bmiidxc        [ beatmania IIDX with DDR 2nd Club Version (896 JAB) ]
+; { Reason 05 } ; bmiidxc2       [ beatmania IIDX Substream 2 with DDR 2nd Club Version (984 A01 BM) ]
+; { Reason 05 } ; bmiidxca       [ beatmania IIDX with DDR 2nd Club Version (896 JAA) ]
+; { Reason 05 } ; crusherm       [ Crusher Makochan (Japan) ]
+; { Reason 05 } ; funquiz        [ Fun World Quiz (Austrian) ]
+; { Reason 05 } ; gq863          [ Twinkle System ]
+; { Reason 05 } ; josvolly       [ Joshi Volleyball ]
+; { Reason 05 } ; lpadv          [ Logic Pro Adventure (Japan) ]
+; { Reason 05 } ; otenamih       [ Otenami Haiken (V2.04J) ]
+; { Reason 05 } ; pbst30         [ Pit Boss Supertouch 30 (9234-10-01) ]
+; { Reason 05 } ; pbst30b        [ Pit Boss Supertouch 30 (9234-00-01) ]
+; { Reason 05 } ; quizvid        [ Video Quiz ]
+; { Reason 05 } ; shangtou       [ Shanghai Sangokuhai Tougi (Ver 2.01J) ]
+; { Reason 05 } ; suprgolf       [ Super Crowns Golf (Japan) ]
+; { Reason 05 } ; waveshrk       [ Wave Shark (UAB, USA v1.04) ]
+; { Reason 06 } ; 3ds            [ Three Ds - Three Dealers Casino House ]
+; { Reason 06 } ; 3super8        [ 3 Super 8 (Italy) ]
+; { Reason 06 } ; 5clown         [ Five Clown (English, set 1) ]
+; { Reason 06 } ; 5clowna        [ Five Clown (English, set 2) ]
+; { Reason 06 } ; 5clownsp       [ Five Clown (Spanish hack) ]
+; { Reason 06 } ; 7mezzo         [ 7 e Mezzo ]
+; { Reason 06 } ; 86lions        [ 86 Lions ]
+; { Reason 06 } ; abnudge        [ Animal Bonus Nudge (Version 2.1 Dual) ]
+; { Reason 06 } ; abnudgeb       [ Animal Bonus Nudge (Version 2.0, set 1) ]
+; { Reason 06 } ; abnudged       [ Animal Bonus Nudge (Version 2.0, set 2) ]
+; { Reason 06 } ; abnudgeo       [ Animal Bonus Nudge (Version 1.7) ]
+; { Reason 06 } ; acefruit       [ unknown ACE fruits game ]
+; { Reason 06 } ; act2000        [ Action 2000 (Version 3.5E Dual) ]
+; { Reason 06 } ; act2000b1      [ Action 2000 (Version 3.5R, set 2) ]
+; { Reason 06 } ; act2000bx      [ Action 2000 (Version 3.30XT, set 2) ]
+; { Reason 06 } ; act2000d1      [ Action 2000 (Version 3.5R, set 1) ]
+; { Reason 06 } ; act2000dx      [ Action 2000 (Version 3.30XT, set 1) ]
+; { Reason 06 } ; act2000o       [ Action 2000 (Version 3.3) ]
+; { Reason 06 } ; act2000o2      [ Action 2000 (Version 3.10XT) ]
+; { Reason 06 } ; act2000o3      [ Action 2000 (Version 1.2) ]
+; { Reason 06 } ; act2000v1      [ Action 2000 (Version 3.5R Dual) ]
+; { Reason 06 } ; act2000vx      [ Action 2000 (Version 3.30XT Dual) ]
+; { Reason 06 } ; ampkr228       [ American Poker II (iamp2 v28) ]
+; { Reason 06 } ; ampkr2b1       [ American Poker II (bootleg, set 1) ]
+; { Reason 06 } ; ampkr2b2       [ American Poker II (bootleg, set 2) ]
+; { Reason 06 } ; ampkr2b3       [ American Poker II (bootleg, set 3) ]
+; { Reason 06 } ; ampkr2b4       [ American Poker II (bootleg, set 4) ]
+; { Reason 06 } ; ampkr95        [ American Poker 95 ]
+; { Reason 06 } ; ampoker2       [ American Poker II ]
+; { Reason 06 } ; amuse1         [ Amuse (Version 30.08 IBA) ]
+; { Reason 06 } ; anibonus       [ Animal Bonus (Version 1.8E Dual) ]
+; { Reason 06 } ; anibonusb1     [ Animal Bonus (Version 1.7R, set 1) ]
+; { Reason 06 } ; anibonusb2     [ Animal Bonus (Version 1.7LT, set 1) ]
+; { Reason 06 } ; anibonusd1     [ Animal Bonus (Version 1.7R, set 2) ]
+; { Reason 06 } ; anibonusd2     [ Animal Bonus (Version 1.7LT, set 2) ]
+; { Reason 06 } ; anibonuso      [ Animal Bonus (Version 1.5) ]
+; { Reason 06 } ; anibonuso2     [ Animal Bonus (Version 1.4, set 1) ]
+; { Reason 06 } ; anibonuso3     [ Animal Bonus (Version 1.4, set 2) ]
+; { Reason 06 } ; anibonusv1     [ Animal Bonus (Version 1.8R Dual) ]
+; { Reason 06 } ; anibonusv2     [ Animal Bonus (Version 1.8LT Dual) ]
+; { Reason 06 } ; anibonusxo     [ Animal Bonus (Version 1.50XT) ]
+; { Reason 06 } ; anibonusxo2    [ Animal Bonus (Version 1.40XT, set 1) ]
+; { Reason 06 } ; anibonusxo3    [ Animal Bonus (Version 1.40XT, set 2) ]
+; { Reason 06 } ; anithunt       [ Animal Treasure Hunt (Version 1.9R, set 1) ]
+; { Reason 06 } ; anithuntd1     [ Animal Treasure Hunt (Version 1.9R, set 2) ]
+; { Reason 06 } ; anithunto      [ Animal Treasure Hunt (Version 1.7) ]
+; { Reason 06 } ; anithunto2     [ Animal Treasure Hunt (Version 1.5) ]
+; { Reason 06 } ; anithuntv1     [ Animal Treasure Hunt (Version 1.9R Dual) ]
+; { Reason 06 } ; atworld        [ Around The World (Version 1.3E CGA) ]
+; { Reason 06 } ; atworldd1      [ Around The World (Version 1.3R CGA) ]
+; { Reason 06 } ; autmoon        [ Autumn Moon ]
+; { Reason 06 } ; babydad        [ Baby Dado ]
+; { Reason 06 } ; babypkr        [ Baby Poker ]
+; { Reason 06 } ; barline        [ Barline (Japan?) ]
+; { Reason 06 } ; big10          [ Big 10 ]
+; { Reason 06 } ; bigappg        [ Big Apple Games ]
+; { Reason 06 } ; bingoc         [ Bingo Circus (Rev. A 891001) ]
+; { Reason 06 } ; bingor5        [ Bingo Roll / Bell Star V3? (set 5) ]
+; { Reason 06 } ; bjpoker        [ Poker / Black Jack (Model 7521) ]
+; { Reason 06 } ; blckjack       [ Black Jack ]
+; { Reason 06 } ; bottl10b       [ Bottle 10 (Italian, set 2) ]
+; { Reason 06 } ; bottle10       [ Bottle 10 (Italian, set 1) ]
+; { Reason 06 } ; brasil         [ Bra$il (Version 3) ]
+; { Reason 06 } ; brasil89       [ Brasil 89 ]
+; { Reason 06 } ; bs94           [ Buena Suerte '94 ]
+; { Reason 06 } ; bsuerte        [ Buena Suerte (Spanish, set 1) ]
+; { Reason 06 } ; bsuertea       [ Buena Suerte (Spanish, set 2) ]
+; { Reason 06 } ; bsuerteb       [ Buena Suerte (Spanish, set 3) ]
+; { Reason 06 } ; bsuertec       [ Buena Suerte (Spanish, set 4) ]
+; { Reason 06 } ; bsuerted       [ Buena Suerte (Spanish, set 5) ]
+; { Reason 06 } ; bsuertee       [ Buena Suerte (Spanish, set 6) ]
+; { Reason 06 } ; bsuertef       [ Buena Suerte (Spanish, set 7) ]
+; { Reason 06 } ; bsuerteg       [ Buena Suerte (Spanish, set 8) ]
+; { Reason 06 } ; bsuerteh       [ Buena Suerte (Spanish, set 9) ]
+; { Reason 06 } ; bsuertei       [ Buena Suerte (Spanish, set 10) ]
+; { Reason 06 } ; bsuertej       [ Buena Suerte (Spanish, set 11) ]
+; { Reason 06 } ; bsuertek       [ Buena Suerte (Spanish, set 12) ]
+; { Reason 06 } ; bsuertel       [ Buena Suerte (Spanish, set 13) ]
+; { Reason 06 } ; bsuertem       [ Buena Suerte (Spanish, set 14) ]
+; { Reason 06 } ; bsuerten       [ Buena Suerte (Spanish, set 15) ]
+; { Reason 06 } ; bsuerteo       [ Buena Suerte (Spanish, set 16) ]
+; { Reason 06 } ; bsuertep       [ Buena Suerte (Spanish, set 17) ]
+; { Reason 06 } ; bsuerteq       [ Buena Suerte (Spanish, set 18) ]
+; { Reason 06 } ; bsuerter       [ Buena Suerte (Spanish, set 19) ]
+; { Reason 06 } ; bsuertes       [ Buena Suerte (Spanish, set 20) ]
+; { Reason 06 } ; bsuertet       [ Buena Suerte (Spanish, set 21) ]
+; { Reason 06 } ; bsuerteu       [ Buena Suerte (Spanish, set 22) ]
+; { Reason 06 } ; bugfever       [ Bugs Fever (Version 1.7R CGA) ]
+; { Reason 06 } ; bugfeverd      [ Bugs Fever (Version 1.7E CGA) ]
+; { Reason 06 } ; bugfevero      [ Bugs Fever (Version 1.6R CGA) ]
+; { Reason 06 } ; bugfeverv      [ Bugs Fever (Version 1.7R Dual) ]
+; { Reason 06 } ; bugfeverv2     [ Bugs Fever (Version 1.7E Dual) ]
+; { Reason 06 } ; buster         [ Buster ]
+; { Reason 06 } ; butrfly        [ Butterfly Video Game (ver.U350C) ]
+; { Reason 06 } ; carb2002       [ Carriage Bonus 2002 (bootleg) ]
+; { Reason 06 } ; carb2003       [ Carriage Bonus 2003 (bootleg) ]
+; { Reason 06 } ; casino5        [ Casino Five ]
+; { Reason 06 } ; caswin         [ Casino Winner ]
+; { Reason 06 } ; cb2001         [ Cherry Bonus 2001 ]
+; { Reason 06 } ; cb3            [ Cherry Bonus III (ver.1.40, encrypted) ]
+; { Reason 06 } ; cb3a           [ Cherry Bonus III (ver.1.40, set 2) ]
+; { Reason 06 } ; cb3b           [ Cherry Bonus III (alt) ]
+; { Reason 06 } ; cchance        [ Cherry Chance ]
+; { Reason 06 } ; cfever1k       [ Casino Fever 1k ]
+; { Reason 06 } ; cfever40       [ Casino Fever 4.0 ]
+; { Reason 06 } ; cfever50       [ Casino Fever 5.0 ]
+; { Reason 06 } ; cfever51       [ Casino Fever 5.1 ]
+; { Reason 06 } ; cfever61       [ Casino Fever 6.1 ]
+; { Reason 06 } ; cgip30cs       [ Credit Poker (ver.30c, standard) ]
+; { Reason 06 } ; ch2000         [ Fruit Bonus 2000 / New Cherry 2000 (Version 4.4E Dual) ]
+; { Reason 06 } ; ch2000b1       [ Fruit Bonus 2000 / New Cherry 2000 (Version 4.4R, set 1) ]
+; { Reason 06 } ; ch2000b2       [ Fruit Bonus 2000 / New Cherry 2000 (Version 4.1LT, set 1) ]
+; { Reason 06 } ; ch2000c1       [ Fruit Bonus 2000 / New Cherry 2000 (Version 4.4R, set 2) ]
+; { Reason 06 } ; ch2000c2       [ Fruit Bonus 2000 / New Cherry 2000 (Version 4.1LT, set 2) ]
+; { Reason 06 } ; ch2000d1       [ Fruit Bonus 2000 / New Cherry 2000 (Version 4.4R, set 3) ]
+; { Reason 06 } ; ch2000d2       [ Fruit Bonus 2000 / New Cherry 2000 (Version 4.1LT, set 3) ]
+; { Reason 06 } ; ch2000o        [ Fruit Bonus 2000 / New Cherry 2000 (Version 3.9XT) ]
+; { Reason 06 } ; ch2000o2       [ Fruit Bonus 2000 / New Cherry 2000 (Version 3.9D) ]
+; { Reason 06 } ; ch2000o3       [ Fruit Bonus 2000 / New Cherry 2000 (Version 3.9) ]
+; { Reason 06 } ; ch2000v1       [ Fruit Bonus 2000 / New Cherry 2000 (Version 4.4R Dual) ]
+; { Reason 06 } ; ch2000v2       [ Fruit Bonus 2000 / New Cherry 2000 (Version 4.1LT Dual) ]
+; { Reason 06 } ; chleague       [ Champion League (Poker) ]
+; { Reason 06 } ; chleagul       [ Champion League (Lattine) ]
+; { Reason 06 } ; chmpnum        [ Champion Number (V0.74) ]
+; { Reason 06 } ; chry10         [ Cherry 10 (bootleg with PIC16F84) ]
+; { Reason 06 } ; chrygld        [ Cherry Gold I ]
+; { Reason 06 } ; chsuper2       [ Champion Super 2 (V0.13) ]
+; { Reason 06 } ; chsuper3       [ Champion Super 3 (V0.35) ]
+; { Reason 06 } ; ciclone        [ Ciclone ]
+; { Reason 06 } ; citalcup       [ Champion Italian Cup (bootleg V220IT) ]
+; { Reason 06 } ; classice       [ Classic Edition (Version 1.6E) ]
+; { Reason 06 } ; classice1      [ Classic Edition (Version 1.6R, set 1) ]
+; { Reason 06 } ; classice2      [ Classic Edition (Version 1.6LT, set 1) ]
+; { Reason 06 } ; classiced1     [ Classic Edition (Version 1.6R, set 2) ]
+; { Reason 06 } ; classiced2     [ Classic Edition (Version 1.6LT, set 2) ]
+; { Reason 06 } ; classicev      [ Classic Edition (Version 1.6E Dual) ]
+; { Reason 06 } ; classicev1     [ Classic Edition (Version 1.6R Dual) ]
+; { Reason 06 } ; classicev2     [ Classic Edition (Version 1.6LT Dual) ]
+; { Reason 06 } ; cmast91        [ Cherry Master '91 (ver.1.30) ]
+; { Reason 06 } ; cmast92        [ Cherry Master '92 ]
+; { Reason 06 } ; cmaster        [ Cherry Master I (ver.1.01, set 1) ]
+; { Reason 06 } ; cmasterb       [ Cherry Master I (ver.1.01, set 2) ]
+; { Reason 06 } ; cmasterbv      [ Cherry Master I (ver.1.01, set 4, with Blitz Poker ROM?) ]
+; { Reason 06 } ; cmasterc       [ Cherry Master I (ver.1.01, set 3) ]
+; { Reason 06 } ; cmasterd       [ Cherry Master I (ver.1.01, set 5) ]
+; { Reason 06 } ; cmastere       [ Cherry Master I (ver.1.01, set 6) ]
+; { Reason 06 } ; cmasterf       [ Cherry Master I (ver.1.01, set 7) ]
+; { Reason 06 } ; cmezspin       [ Cherry Master I (E-Z Spin bootleg / hack) ]
+; { Reason 06 } ; cmfun          [ Cherry Master (Fun USA v2.5 bootleg / hack) ]
+; { Reason 06 } ; cmv4           [ Cherry Master (ver.4, set 1) ]
+; { Reason 06 } ; cmv4a          [ Cherry Master (ver.4, set 2) ]
+; { Reason 06 } ; cmv801         [ Cherry Master (Corsica, ver.8.01) ]
+; { Reason 06 } ; cmwm           [ Cherry Master (Watermelon bootleg / hack) ]
+; { Reason 06 } ; cntrygrl       [ Country Girl (Japan set 1) ]
+; { Reason 06 } ; cntrygrla      [ Country Girl (Japan set 2) ]
+; { Reason 06 } ; comg074        [ Cal Omega - Game 7.4 (Gaming Poker, W.Export) ]
+; { Reason 06 } ; comg076        [ Cal Omega - Game 7.6 (Arcade Poker) ]
+; { Reason 06 } ; cpokerpk       [ Champion Italian PK (bootleg, blue board) ]
+; { Reason 06 } ; cpokerpkg      [ Champion Italian PK (bootleg, green board) ]
+; { Reason 06 } ; crsbingo       [ Poker Carnival ]
+; { Reason 06 } ; crzmon_7       [ Crazy Monkey (031110) ]
+; { Reason 06 } ; crzmon_7a      [ Crazy Monkey (031110, backdoor set 1) ]
+; { Reason 06 } ; crzmon_7b      [ Crazy Monkey (031110, backdoor set 2) ]
+; { Reason 06 } ; crzmon_8       [ Crazy Monkey (050120) ]
+; { Reason 06 } ; crzmon_8a      [ Crazy Monkey (050120, backdoor) ]
+; { Reason 06 } ; cuoreuno       [ Cuore 1 (Italian) ]
+; { Reason 06 } ; d9final        [ Dream 9 Final (v2.24) ]
+; { Reason 06 } ; dblchal        [ Double Challenge (Version 1.5R, set 1) ]
+; { Reason 06 } ; dblchalc1      [ Double Challenge (Version 1.5R, set 2) ]
+; { Reason 06 } ; dblchald1      [ Double Challenge (Version 1.5R, set 3) ]
+; { Reason 06 } ; dblchalo       [ Double Challenge (Version 1.1) ]
+; { Reason 06 } ; dblchalv1      [ Double Challenge (Version 1.5R Dual) ]
+; { Reason 06 } ; dealem         [ Deal 'Em (MPU4 Conversion Kit, v7.0) ]
+; { Reason 06 } ; dealer         [ The Dealer ]
+; { Reason 06 } ; df_djpkr       [ Double Joker Poker (45%-75% payout) ]
+; { Reason 06 } ; dphl           [ Draw Poker HI-LO (M.Kramer) ]
+; { Reason 06 } ; dphla          [ Draw Poker HI-LO (Alt) ]
+; { Reason 06 } ; drhl           [ DRHL Poker (v.2.89) ]
+; { Reason 06 } ; drw80pk2       [ Draw 80 Poker - Minn ]
+; { Reason 06 } ; elephfam       [ Elephant Family (Italian, new) ]
+; { Reason 06 } ; elephfmb       [ Elephant Family (Italian, old) ]
+; { Reason 06 } ; fashion        [ Fashion (Version 2.14) ]
+; { Reason 06 } ; fb2gen         [ Fruit Bonus 2nd Generation (Version 1.8E Dual) ]
+; { Reason 06 } ; fb2genc1       [ Fruit Bonus 2nd Generation (Version 1.8R, set 1) ]
+; { Reason 06 } ; fb2genc2       [ Fruit Bonus 2nd Generation (Version 1.8LT, set 1) ]
+; { Reason 06 } ; fb2gend1       [ Fruit Bonus 2nd Generation (Version 1.8R, set 2) ]
+; { Reason 06 } ; fb2gend2       [ Fruit Bonus 2nd Generation (Version 1.8LT, set 2) ]
+; { Reason 06 } ; fb2geno        [ Fruit Bonus 2nd Generation (Version 1.6XT) ]
+; { Reason 06 } ; fb2geno2       [ Fruit Bonus 2nd Generation (Version 1.5) ]
+; { Reason 06 } ; fb2genv1       [ Fruit Bonus 2nd Generation (Version 1.8R Dual) ]
+; { Reason 06 } ; fb2genv2       [ Fruit Bonus 2nd Generation (Version 1.8LT Dual) ]
+; { Reason 06 } ; fb2nd          [ Fruit Bonus 2nd Edition (Version 1.8R, set 1) ]
+; { Reason 06 } ; fb2ndc2        [ Fruit Bonus 2nd Edition (Version 1.8LT, set 1) ]
+; { Reason 06 } ; fb2ndd1        [ Fruit Bonus 2nd Edition (Version 1.8R, set 2) ]
+; { Reason 06 } ; fb2ndd2        [ Fruit Bonus 2nd Edition (Version 1.8LT, set 2) ]
+; { Reason 06 } ; fb2ndo         [ Fruit Bonus 2nd Edition (Version 1.5) ]
+; { Reason 06 } ; fb2ndv1        [ Fruit Bonus 2nd Edition (Version 1.8R Dual) ]
+; { Reason 06 } ; fb2ndv2        [ Fruit Bonus 2nd Edition (Version 1.8LT Dual) ]
+; { Reason 06 } ; fb4            [ Fruit Bonus 2004 (Version 1.5R, set 1) ]
+; { Reason 06 } ; fb4b2          [ Fruit Bonus 2004 (Version 1.5LT, set 1) ]
+; { Reason 06 } ; fb4c1          [ Fruit Bonus 2004 (Version 1.5R, set 2) ]
+; { Reason 06 } ; fb4c2          [ Fruit Bonus 2004 (Version 1.5LT, set 2) ]
+; { Reason 06 } ; fb4d1          [ Fruit Bonus 2004 (Version 1.5R, set 3) ]
+; { Reason 06 } ; fb4d2          [ Fruit Bonus 2004 (Version 1.5LT, set 3) ]
+; { Reason 06 } ; fb4exp         [ Fruit Bonus 2005 (2004 Export - Version 1.5E Dual) ]
+; { Reason 06 } ; fb4o           [ Fruit Bonus 2004 (Version 1.3XT) ]
+; { Reason 06 } ; fb4o2          [ Fruit Bonus 2004 (Version 1.2) ]
+; { Reason 06 } ; fb4v1          [ Fruit Bonus 2004 (Version 1.5R Dual) ]
+; { Reason 06 } ; fb4v2          [ Fruit Bonus 2004 (Version 1.5LT Dual) ]
+; { Reason 06 } ; fb5            [ Fruit Bonus 2005 (Version 1.5SH, set 1) ]
+; { Reason 06 } ; fb5c           [ Fruit Bonus 2005 (Version 1.5SH, set 2) ]
+; { Reason 06 } ; fb5d           [ Fruit Bonus 2005 (Version 1.5SH, set 3) ]
+; { Reason 06 } ; fb5v           [ Fruit Bonus 2005 (Version 1.5SH Dual) ]
+; { Reason 06 } ; fb6            [ Fruit Bonus '06 - 10th anniversary (Version 1.7E CGA) ]
+; { Reason 06 } ; fb6d1          [ Fruit Bonus '06 - 10th anniversary (Version 1.7R CGA, set 1) ]
+; { Reason 06 } ; fb6d2          [ Fruit Bonus '06 - 10th anniversary (Version 1.7LT CGA, set 1) ]
+; { Reason 06 } ; fb6s1          [ Fruit Bonus '06 - 10th anniversary (Version 1.7R CGA, set 2) ]
+; { Reason 06 } ; fb6s2          [ Fruit Bonus '06 - 10th anniversary (Version 1.7LT CGA, set 2) ]
+; { Reason 06 } ; fb6s3          [ Fruit Bonus '06 - 10th anniversary (Version 1.3R CGA) ]
+; { Reason 06 } ; fb6se          [ Fruit Bonus 2006 Special Edition (Version 1.4E CGA) ]
+; { Reason 06 } ; fb6sed1        [ Fruit Bonus 2006 Special Edition (Version 1.4R CGA) ]
+; { Reason 06 } ; fb6sed2        [ Fruit Bonus 2006 Special Edition (Version 1.4LT CGA) ]
+; { Reason 06 } ; fb6sev         [ Fruit Bonus 2006 Special Edition (Version 1.4E Dual) ]
+; { Reason 06 } ; fb6sev1        [ Fruit Bonus 2006 Special Edition (Version 1.4R Dual) ]
+; { Reason 06 } ; fb6sev2        [ Fruit Bonus 2006 Special Edition (Version 1.4LT Dual) ]
+; { Reason 06 } ; fb6v           [ Fruit Bonus '06 - 10th anniversary (Version 1.7E Dual) ]
+; { Reason 06 } ; fb6v1          [ Fruit Bonus '06 - 10th anniversary (Version 1.7R Dual) ]
+; { Reason 06 } ; fb6v2          [ Fruit Bonus '06 - 10th anniversary (Version 1.7LT Dual) ]
+; { Reason 06 } ; fcnudge        [ Fruit Carnival Nudge (Version 2.1 Dual) ]
+; { Reason 06 } ; fcnudgeo       [ Fruit Carnival Nudge (Version 2.0, set 1) ]
+; { Reason 06 } ; fcnudgeo2      [ Fruit Carnival Nudge (Version 2.0, set 2) ]
+; { Reason 06 } ; fcnudgeo3      [ Fruit Carnival Nudge (Version 1.7) ]
+; { Reason 06 } ; fcockt_6       [ Fruit Cocktail (040216) ]
+; { Reason 06 } ; fcockt_6a      [ Fruit Cocktail (040216, banking address hack) ]
+; { Reason 06 } ; fcockt_6b      [ Fruit Cocktail (040216, backdoor) ]
+; { Reason 06 } ; fcockt_7       [ Fruit Cocktail (050118) ]
+; { Reason 06 } ; fcockt_7a      [ Fruit Cocktail (050118, backdoor) ]
+; { Reason 06 } ; fcockt_8       [ Fruit Cocktail (060111) ]
+; { Reason 06 } ; feversoc       [ Fever Soccer ]
+; { Reason 06 } ; ffortune       [ Fantasy Fortune ]
+; { Reason 06 } ; fortune1       [ Fortune I (PK485-S) Draw Poker ]
+; { Reason 06 } ; fruitbun       [ Fruits & Bunny (World?) ]
+; { Reason 06 } ; funcsino       [ Status Fun Casino (V1.3s) ]
+; { Reason 06 } ; funlddlx       [ Funny Land de Luxe ]
+; { Reason 06 } ; funriver       [ Fun River (set 1) ]
+; { Reason 06 } ; funriverv      [ Fun River (set 2) ]
+; { Reason 06 } ; galaxi         [ Galaxi (v2.0) ]
+; { Reason 06 } ; garage_4       [ Garage (040219) ]
+; { Reason 06 } ; garage_4a      [ Garage (040219, backdoor) ]
+; { Reason 06 } ; garage_4b      [ Garage (040219, changed version text) ]
+; { Reason 06 } ; garage_5       [ Garage (050311) ]
+; { Reason 06 } ; garage_5a      [ Garage (050311, backdoor) ]
+; { Reason 06 } ; gegege         [ GeGeGe no Kitarou Youkai Slot ]
+; { Reason 06 } ; geimulti       [ GEI Multi Game ]
+; { Reason 06 } ; goodluck       [ Good Luck ]
+; { Reason 06 } ; grtesoro       [ Gran Tesoro? / Play 2000 (v5.01) (Italy) ]
+; { Reason 06 } ; hitpoker       [ Hit Poker (Bulgaria) ]
+; { Reason 06 } ; hldspin1       [ Hold & Spin I (Version 2.7T, set 1) ]
+; { Reason 06 } ; hldspin1dt     [ Hold & Spin I (Version 2.7T, set 2) ]
+; { Reason 06 } ; hldspin1o      [ Hold & Spin I (Version 2.5T) ]
+; { Reason 06 } ; hldspin1vt     [ Hold & Spin I (Version 2.7T Dual) ]
+; { Reason 06 } ; hldspin2       [ Hold & Spin II (Version 2.8R, set 1) ]
+; { Reason 06 } ; hldspin2d1     [ Hold & Spin II (Version 2.8R, set 2) ]
+; { Reason 06 } ; hldspin2o      [ Hold & Spin II (Version 2.6) ]
+; { Reason 06 } ; hldspin2v1     [ Hold & Spin II (Version 2.8R Dual) ]
+; { Reason 06 } ; hotslot        [ Hot Slot (ver. 05.01) ]
+; { Reason 06 } ; igs_ncs        [ New Champion Skill (v100n) ]
+; { Reason 06 } ; igs_ncs2       [ New Champion Skill (v100n 2000) ]
+; { Reason 06 } ; island2        [ Island 2 (060529) ]
+; { Reason 06 } ; island2a       [ Island 2 (060529, banking address hack) ]
+; { Reason 06 } ; islanda        [ Island (050713, backdoor) ]
+; { Reason 06 } ; jackpool       [ Jackpot Cards / Jackpot Pool (Italy) ]
+; { Reason 06 } ; jingbell       [ Jingle Bell (Italy, V133I) ]
+; { Reason 06 } ; jockeyc        [ Jockey Club ]
+; { Reason 06 } ; jokpoker       [ Joker Poker (Version 16.03B) ]
+; { Reason 06 } ; jokpokera      [ Joker Poker (Version 16.03BI) ]
+; { Reason 06 } ; jokpokerb      [ Joker Poker (Version 16.04BI 10-19-88, Joker Poker ICB 9-30-86) ]
+; { Reason 06 } ; jokpokerc      [ Joker Poker (Version 16.03BI 5-10-85, Poker No Raise ICB 9-30-86) ]
+; { Reason 06 } ; jokrwild       [ Joker's Wild (encrypted) ]
+; { Reason 06 } ; jolyc3x3       [ Jolly Card (3x3 deal) ]
+; { Reason 06 } ; jolyc980       [ Jolly Card Professional 2.0 (Spale Soft) ]
+; { Reason 06 } ; jolycdev       [ Jolly Card (Evona Electronic) ]
+; { Reason 06 } ; jolycdib       [ Jolly Card (Italian, encrypted bootleg) ]
+; { Reason 06 } ; jolycdit       [ Jolly Card (Italian, blue TAB board, encrypted) ]
+; { Reason 06 } ; jolycmzs       [ Jolly Card Professional 2.0 (MZS Tech) ]
+; { Reason 06 } ; jolyjokr       [ Jolly Joker (98bet, set 1) ]
+; { Reason 06 } ; jolyjokra      [ Jolly Joker (98bet, set 2) ]
+; { Reason 06 } ; jolyjokrb      [ Jolly Joker (40bet, Croatian hack) ]
+; { Reason 06 } ; jwildb52       [ Joker's Wild (B52 system, set 1) ]
+; { Reason 06 } ; jwildb52a      [ Joker's Wild (B52 system, set 2) ]
+; { Reason 06 } ; jwildb52h      [ Joker's Wild (B52 system, Harrah's GFX) ]
+; { Reason 06 } ; keks           [ Keks (060328) ]
+; { Reason 06 } ; keksa          [ Keks (060328, banking address hack) ]
+; { Reason 06 } ; keksb          [ Keks (060328, backdoor) ]
+; { Reason 06 } ; keksc          [ Keks (060328, banking address hack, changed version text) ]
+; { Reason 06 } ; keks_2         [ Keks (060403) ]
+; { Reason 06 } ; keks_2a        [ Keks (060403, banking address hack) ]
+; { Reason 06 } ; keks_2b        [ Keks (060403, banking address hack, changed version text) ]
+; { Reason 06 } ; kingdrbb       [ King Derby (Taiwan bootleg) ]
+; { Reason 06 } ; kingdrby       [ King Derby (1981) ]
+; { Reason 06 } ; kkojnoli       [ Kkoj Noli (Kill the Bees) ]
+; { Reason 06 } ; koftball       [ King of Football ]
+; { Reason 06 } ; lhaunt_4       [ Lucky Haunter (031111) ]
+; { Reason 06 } ; lhaunt_4a      [ Lucky Haunter (031111, backdoor) ]
+; { Reason 06 } ; lhaunt_5       [ Lucky Haunter (040216) ]
+; { Reason 06 } ; lhaunt_5a      [ Lucky Haunter (040216, backdoor) ]
+; { Reason 06 } ; lhaunt_6       [ Lucky Haunter (040825) ]
+; { Reason 06 } ; lhaunt_6a      [ Lucky Haunter (040825, backdoor) ]
+; { Reason 06 } ; lluck3x3       [ Lucky Lady (3x3 deal) ]
+; { Reason 06 } ; lluck4x1       [ Lucky Lady (4x1 aces) ]
+; { Reason 06 } ; ltcasinn       [ Little Casino (newer) ]
+; { Reason 06 } ; ltcasino       [ Little Casino (older) ]
+; { Reason 06 } ; luckgrln       [ Lucky Girl (newer Z180 based hardware) ]
+; { Reason 06 } ; lucky74        [ Lucky 74 (bootleg, set 1) ]
+; { Reason 06 } ; lucky74a       [ Lucky 74 (bootleg, set 2) ]
+; { Reason 06 } ; luckygrl       [ Lucky Girl? (Wing) ]
+; { Reason 06 } ; madzoo         [ Mad Zoo (ver.U450C) ]
+; { Reason 06 } ; magical        [ Magical Odds (set 1) ]
+; { Reason 06 } ; magicala       [ Magical Odds (set 2) ]
+; { Reason 06 } ; magicard       [ Magic Card (set 1) ]
+; { Reason 06 } ; magicarda      [ Magic Card (set 2) ]
+; { Reason 06 } ; magicardb      [ Magic Card (set 3) ]
+; { Reason 06 } ; magicardj      [ Magic Card Jackpot (4.01) ]
+; { Reason 06 } ; magicle        [ Magic Lotto Export (5.03) ]
+; { Reason 06 } ; magjoker       [ Magic Joker (v1.25.10.2000) ]
+; { Reason 06 } ; mainline       [ Mainline Double Joker Poker ]
+; { Reason 06 } ; margmgc        [ Margarita Magic (A - 07/07/2000, NSW/ACT) ]
+; { Reason 06 } ; mfish_11       [ Multi Fish (031124) ]
+; { Reason 06 } ; mfish_12       [ Multi Fish (040308) ]
+; { Reason 06 } ; mfish_12a      [ Multi Fish (040308, banking address hack) ]
+; { Reason 06 } ; mfish_3        [ Multi Fish (021124) ]
+; { Reason 06 } ; mfish_3a       [ Multi Fish (021124, banking address hack) ]
+; { Reason 06 } ; mfish_6        [ Multi Fish (030124) ]
+; { Reason 06 } ; mgnumber       [ Magic Number ]
+; { Reason 06 } ; mgprem11       [ Magic Premium (v1.1) ]
+; { Reason 06 } ; mil4000        [ Millennium Nuovo 4000 (Version 2.0) ]
+; { Reason 06 } ; mil4000a       [ Millennium Nuovo 4000 (Version 1.8) ]
+; { Reason 06 } ; mil4000b       [ Millennium Nuovo 4000 (Version 1.5) ]
+; { Reason 06 } ; mil4000c       [ Millennium Nuovo 4000 (Version 1.6) ]
+; { Reason 06 } ; moneybnk       [ Money In The Bank (NSW) ]
+; { Reason 06 } ; moneymac       [ Money Machine (Version 1.7E Dual) ]
+; { Reason 06 } ; moneymacd1     [ Money Machine (Version 1.7R) ]
+; { Reason 06 } ; moneymacd2     [ Money Machine (Version 1.7LT) ]
+; { Reason 06 } ; moneymacv1     [ Money Machine (Version 1.7R Dual) ]
+; { Reason 06 } ; moneymacv2     [ Money Machine (Version 1.7LT Dual) ]
+; { Reason 06 } ; monkeyba       [ Monkey Ball (GDS-0008) ]
+; { Reason 06 } ; monoplcl       [ Monopoly Classic ]
+; { Reason 06 } ; monopldx       [ Monopoly Deluxe ]
+; { Reason 06 } ; monopoly       [ Monopoly ]
+; { Reason 06 } ; mouseatk       [ Mouse Attack ]
+; { Reason 06 } ; mpoker         [ Multi-Poker ]
+; { Reason 06 } ; murogem        [ Muroge Monaco (set 1) ]
+; { Reason 06 } ; murogema       [ Muroge Monaco (set 2) ]
+; { Reason 06 } ; murogmbl       [ Muroge Monaco (bootleg?) ]
+; { Reason 06 } ; m_bcgslm       [ Club Grandslam (UK, Game Card 95-750-843) ]
+; { Reason 06 } ; m_bdrw10       [ Dr.Who The Timelord (set 11) ]
+; { Reason 06 } ; m_bdrw11       [ Dr.Who The Timelord (set 12) ]
+; { Reason 06 } ; m_bdrw12       [ Dr.Who The Timelord (set 13) ]
+; { Reason 06 } ; m_bdrw13       [ Dr.Who The Timelord (set 14) ]
+; { Reason 06 } ; m_bdrw14       [ Dr.Who The Timelord (set 15) ]
+; { Reason 06 } ; m_bdrw15       [ Dr.Who The Timelord (set 16) ]
+; { Reason 06 } ; m_bdrw16       [ Dr.Who The Timelord (set 17) ]
+; { Reason 06 } ; m_bdrw17       [ Dr.Who The Timelord (set 18, not encrypted) ]
+; { Reason 06 } ; m_bdrwh1       [ Dr.Who The Timelord (set 2, UK, Game Card 95-750-661) ]
+; { Reason 06 } ; m_bdrwh2       [ Dr.Who The Timelord (set 3) ]
+; { Reason 06 } ; m_bdrwh3       [ Dr.Who The Timelord (set 4) ]
+; { Reason 06 } ; m_bdrwh4       [ Dr.Who The Timelord (set 5) ]
+; { Reason 06 } ; m_bdrwh5       [ Dr.Who The Timelord (set 6) ]
+; { Reason 06 } ; m_bdrwh6       [ Dr.Who The Timelord (set 7) ]
+; { Reason 06 } ; m_bdrwh7       [ Dr.Who The Timelord (set 8) ]
+; { Reason 06 } ; m_bdrwh8       [ Dr.Who The Timelord (set 9) ]
+; { Reason 06 } ; m_bdrwh9       [ Dr.Who The Timelord (set 10) ]
+; { Reason 06 } ; m_bdrwho       [ Dr.Who The Timelord (set 1, UK, Game Card 95-750-288) ]
+; { Reason 06 } ; m_brkfs1       [ The Big Breakfast (Set 2) ]
+; { Reason 06 } ; m_brkfs2       [ The Big Breakfast (Set 3) ]
+; { Reason 06 } ; m_brkfs3       [ The Big Breakfast (Set 4) ]
+; { Reason 06 } ; m_brkfs4       [ The Big Breakfast (Set 5) ]
+; { Reason 06 } ; m_brkfs5       [ The Big Breakfast (Set 6) ]
+; { Reason 06 } ; m_roulet       [ Roulette (Dutch, Game Card 39-360-129?) ]
+; { Reason 06 } ; m_tbirds       [ Thunderbirds ]
+; { Reason 06 } ; m_tppokr       [ Toppoker (Dutch, Game Card 95-750-899) ]
+; { Reason 06 } ; nc96           [ New Cherry '96 Special Edition (set 1) ]
+; { Reason 06 } ; nc96a          [ New Cherry '96 Special Edition (set 2) ]
+; { Reason 06 } ; nc96b          [ New Cherry '96 Special Edition (set 3) ]
+; { Reason 06 } ; nc96c          [ New Cherry '96 Special Edition (set 4) ]
+; { Reason 06 } ; nc96txt        [ New Cherry '96 Special Edition (set 5, Texas XT) ]
+; { Reason 06 } ; ncb3           [ Cherry Bonus III (ver.1.40, set 1) ]
+; { Reason 06 } ; ndxron10       [ Royal on Ten (Noraut Deluxe hack) ]
+; { Reason 06 } ; nfb96          [ New Fruit Bonus '96 Special Edition (set 1) ]
+; { Reason 06 } ; nfb96a         [ New Fruit Bonus '96 Special Edition (set 2) ]
+; { Reason 06 } ; nfb96b         [ New Fruit Bonus '96 Special Edition (set 3) ]
+; { Reason 06 } ; nfb96c         [ New Fruit Bonus '96 Special Edition (set 4) ]
+; { Reason 06 } ; nfb96se        [ New Fruit Bonus '96 Special Edition (bootleg, set 1) ]
+; { Reason 06 } ; nfb96sea       [ New Fruit Bonus '96 Special Edition (bootleg, set 2) ]
+; { Reason 06 } ; nfb96seb       [ New Fruit Bonus '96 Special Edition (bootleg, set 3) ]
+; { Reason 06 } ; nfb96txt       [ New Fruit Bonus '96 Special Edition (set 5, Texas XT) ]
+; { Reason 06 } ; noraut3a       [ Noraut Joker Poker (V3.010a) ]
+; { Reason 06 } ; noraut3b       [ Noraut Joker Poker (V3.011a) ]
+; { Reason 06 } ; norautdx       [ Noraut Deluxe Poker (console) ]
+; { Reason 06 } ; norautjo       [ Noraut Joker Poker (original) ]
+; { Reason 06 } ; norautjp       [ Noraut Joker Poker (alt) ]
+; { Reason 06 } ; norautp        [ Noraut Poker ]
+; { Reason 06 } ; norautpl       [ Noraut Joker Poker (Prologic HW) ]
+; { Reason 06 } ; norautpn       [ Noraut Deluxe Poker (bootleg) ]
+; { Reason 06 } ; norautra       [ Noraut Red Hot Joker Poker (alt HW) ]
+; { Reason 06 } ; norautrh       [ Noraut Red Hot Joker Poker ]
+; { Reason 06 } ; norautu        [ Noraut Poker (NTX10A) ]
+; { Reason 06 } ; norautua       [ Noraut unknown set 1 (console) ]
+; { Reason 06 } ; norautub       [ Noraut unknown set 2 (console) ]
+; { Reason 06 } ; ns8lines       [ New Lucky 8 Lines / New Super 8 Lines (W-4) ]
+; { Reason 06 } ; number10       [ Number Dieci (Poker) ]
+; { Reason 06 } ; numbr10l       [ Number Dieci (Lattine) ]
+; { Reason 06 } ; parentj        [ Parent Jack ]
+; { Reason 06 } ; parrot3        [ Parrot Poker III (Version 2.6E Dual) ]
+; { Reason 06 } ; parrot3b1      [ Parrot Poker III (Version 2.6R, set 1) ]
+; { Reason 06 } ; parrot3d1      [ Parrot Poker III (Version 2.6R, set 2) ]
+; { Reason 06 } ; parrot3o       [ Parrot Poker III (Version 2.4) ]
+; { Reason 06 } ; parrot3v1      [ Parrot Poker III (Version 2.6R Dual) ]
+; { Reason 06 } ; pebe0014       [ Player's Edge Plus (BE0014) Blackjack ]
+; { Reason 06 } ; peke1012       [ Player's Edge Plus (KE1012) Keno ]
+; { Reason 06 } ; pepp0043       [ Player's Edge Plus (PP0043) 10's or Better ]
+; { Reason 06 } ; pepp0065       [ Player's Edge Plus (PP0065) Jokers Wild Poker ]
+; { Reason 06 } ; pepp0158       [ Player's Edge Plus (PP0158) 4 of a Kind Bonus Poker ]
+; { Reason 06 } ; pepp0188       [ Player's Edge Plus (PP0188) Standard Draw Poker ]
+; { Reason 06 } ; pepp0250       [ Player's Edge Plus (PP0250) Double Down Stud Poker ]
+; { Reason 06 } ; pepp0447       [ Player's Edge Plus (PP0447) Standard Draw Poker ]
+; { Reason 06 } ; pepp0516       [ Player's Edge Plus (PP0516) Double Bonus Poker ]
+; { Reason 06 } ; peps0014       [ Player's Edge Plus (PS0014) Super Joker Slots ]
+; { Reason 06 } ; peps0022       [ Player's Edge Plus (PS0022) Red White & Blue Slots ]
+; { Reason 06 } ; peps0043       [ Player's Edge Plus (PS0043) Double Diamond Slots ]
+; { Reason 06 } ; peps0045       [ Player's Edge Plus (PS0045) Red White & Blue Slots ]
+; { Reason 06 } ; peps0308       [ Player's Edge Plus (PS0308) Double Jackpot Slots ]
+; { Reason 06 } ; peps0615       [ Player's Edge Plus (PS0615) Chaos Slots ]
+; { Reason 06 } ; peps0716       [ Player's Edge Plus (PS0716) River Gambler Slots ]
+; { Reason 06 } ; peset038       [ Player's Edge Plus (Set038) Set Chip ]
+; { Reason 06 } ; pex2069p       [ Player's Edge Plus (X002069P) Double Double Bonus Poker ]
+; { Reason 06 } ; pexmp006       [ Player's Edge Plus (XMP00006) Multi-Poker ]
+; { Reason 06 } ; pexmp017       [ Player's Edge Plus (XMP00017) 5-in-1 Wingboard ]
+; { Reason 06 } ; pexmp024       [ Player's Edge Plus (XMP00024) Multi-Poker ]
+; { Reason 06 } ; pexp0019       [ Player's Edge Plus (XP000019) Deuces Wild Poker ]
+; { Reason 06 } ; pexp0112       [ Player's Edge Plus (XP000112) White Hot Aces Poker ]
+; { Reason 06 } ; pexs0006       [ Player's Edge Plus (XS000006) Triple Triple Diamond Slots ]
+; { Reason 06 } ; pickwin        [ Pick 'n Win (Version 2.9E Dual) ]
+; { Reason 06 } ; pickwinb1      [ Pick 'n Win (Version 2.9R, set 1) ]
+; { Reason 06 } ; pickwinbt      [ Pick 'n Win (Version 2.8T, set 1) ]
+; { Reason 06 } ; pickwind1      [ Pick 'n Win (Version 2.9R, set 2) ]
+; { Reason 06 } ; pickwindt      [ Pick 'n Win (Version 2.8T, set 2) ]
+; { Reason 06 } ; pickwino       [ Pick 'n Win (Version 2.6) ]
+; { Reason 06 } ; pickwino2      [ Pick 'n Win (Version 2.5T) ]
+; { Reason 06 } ; pickwinv1      [ Pick 'n Win (Version 2.9R Dual) ]
+; { Reason 06 } ; pickwinvt      [ Pick 'n Win (Version 2.8T, Dual) ]
+; { Reason 06 } ; pir2001        [ Pirate 2001 (Version 2.5E Dual) ]
+; { Reason 06 } ; pir2001b1      [ Pirate 2001 (Version 2.5R, set 1) ]
+; { Reason 06 } ; pir2001bx      [ Pirate 2001 (Version 2.40XT, set 1) ]
+; { Reason 06 } ; pir2001d1      [ Pirate 2001 (Version 2.5R, set 2) ]
+; { Reason 06 } ; pir2001dx      [ Pirate 2001 (Version 2.40XT, set 2) ]
+; { Reason 06 } ; pir2001o       [ Pirate 2001 (Version 2.3N) ]
+; { Reason 06 } ; pir2001o2      [ Pirate 2001 (Version 2.3) ]
+; { Reason 06 } ; pir2001o3      [ Pirate 2001 (Version 2.20XT) ]
+; { Reason 06 } ; pir2001v1      [ Pirate 2001 (Version 2.5R Dual) ]
+; { Reason 06 } ; pir2001vx      [ Pirate 2001 (Version 2.40XT Dual) ]
+; { Reason 06 } ; pir2002        [ Pirate 2002 (Version 2.0E Dual) ]
+; { Reason 06 } ; pir2002b1      [ Pirate 2002 (Version 2.0R, set 1) ]
+; { Reason 06 } ; pir2002bx      [ Pirate 2002 (Version 1.90XT, set 1) ]
+; { Reason 06 } ; pir2002d1      [ Pirate 2002 (Version 2.0R, set 2) ]
+; { Reason 06 } ; pir2002dx      [ Pirate 2002 (Version 1.90XT, set 2) ]
+; { Reason 06 } ; pir2002o       [ Pirate 2002 (Version 1.8N) ]
+; { Reason 06 } ; pir2002o2      [ Pirate 2002 (Version 1.8) ]
+; { Reason 06 } ; pir2002o3      [ Pirate 2002 (Version 1.70XT) ]
+; { Reason 06 } ; pir2002v1      [ Pirate 2002 (Version 2.0R Dual) ]
+; { Reason 06 } ; pir2002vx      [ Pirate 2002 (Version 1.90XT Dual) ]
+; { Reason 06 } ; pirate2        [ Pirate 2 (061005) ]
+; { Reason 06 } ; pirate2a       [ Pirate 2 (061005, banking address hack set 1) ]
+; { Reason 06 } ; pirate2b       [ Pirate 2 (061005, banking address hack set 2) ]
+; { Reason 06 } ; pirate2c       [ Pirate 2 (061005, banking address hack, changed version text set 1) ]
+; { Reason 06 } ; pirate2d       [ Pirate 2 (061005, banking address hack, changed version text set 2) ]
+; { Reason 06 } ; pirate2e       [ Pirate 2 (061005, banking address hack, changed version text set 3) ]
+; { Reason 06 } ; pirate_2       [ Pirate (060210) ]
+; { Reason 06 } ; pirate_3       [ Pirate (060803) ]
+; { Reason 06 } ; pirpok2        [ Pirate Poker II (Version 2.4E Dual) ]
+; { Reason 06 } ; pirpok2b1      [ Pirate Poker II (Version 2.2R, set 1) ]
+; { Reason 06 } ; pirpok2d1      [ Pirate Poker II (Version 2.2R, set 2) ]
+; { Reason 06 } ; pirpok2o       [ Pirate Poker II (Version 2.0) ]
+; { Reason 06 } ; pirpok2v1      [ Pirate Poker II (Version 2.2R Dual) ]
+; { Reason 06 } ; pitboss        [ The Pit Boss (Set 1) ]
+; { Reason 06 } ; pitboss2       [ Pit Boss II ]
+; { Reason 06 } ; pitbossa       [ The Pit Boss (Set 2) ]
+; { Reason 06 } ; pitbossb       [ The Pit Boss (Set 3) ]
+; { Reason 06 } ; pitbossc       [ The Pit Boss (Set 4) ]
+; { Reason 06 } ; pitbosss       [ Pit Boss Superstar ]
+; { Reason 06 } ; pkrdewin       [ Poker De Win ]
+; { Reason 06 } ; pkrmast        [ Poker Master (set 1) ]
+; { Reason 06 } ; pkrmasta       [ Poker Master (set 2) ]
+; { Reason 06 } ; pma            [ PMA Poker ]
+; { Reason 06 } ; poker91        [ Poker 91 ]
+; { Reason 06 } ; pokeroul       [ Poker Roulette (Version 8.22) ]
+; { Reason 06 } ; pokonl97       [ Poker Only '97 (ver. 3.3) ]
+; { Reason 06 } ; pool10         [ Pool 10 (Italian, set 1) ]
+; { Reason 06 } ; pool10b        [ Pool 10 (Italian, set 2) ]
+; { Reason 06 } ; pool10c        [ Pool 10 (Italian, set 3) ]
+; { Reason 06 } ; pool10d        [ Pool 10 (Italian, set 4) ]
+; { Reason 06 } ; potnpkrb       [ Jack Potten's Poker (set 3) ]
+; { Reason 06 } ; potnpkrc       [ Jack Potten's Poker (set 4) ]
+; { Reason 06 } ; potnpkrd       [ Jack Potten's Poker (set 5) ]
+; { Reason 06 } ; potnpkre       [ Jack Potten's Poker (set 6) ]
+; { Reason 06 } ; ppan           [ Peter Pan (bootleg of Hook) ]
+; { Reason 06 } ; qc             [ Quarter Horse Classic ]
+; { Reason 06 } ; rabbitpk       [ Rabbit Poker (Arizona Poker v1.1?) ]
+; { Reason 06 } ; rclimb_3a      [ Rock Climber (040827, backdoor) ]
+; { Reason 06 } ; rclimb_3b      [ Rock Climber (040827, new service menu) ]
+; { Reason 06 } ; reelrock       [ Reelin-n-Rockin (A - 13/07/98, Local) ]
+; { Reason 06 } ; resdnt_2       [ Resident (040513) ]
+; { Reason 06 } ; resdnt_2a      [ Resident (040513, backdoor) ]
+; { Reason 06 } ; robadv         [ Robin's Adventure (Version 1.7E Dual) ]
+; { Reason 06 } ; robadv2        [ Robin's Adventure 2 (Version 1.7E Dual) ]
+; { Reason 06 } ; robadv2c1      [ Robin's Adventure 2 (Version 1.7R, set 1) ]
+; { Reason 06 } ; robadv2c2      [ Robin's Adventure 2 (Version 1.7LT, set 1) ]
+; { Reason 06 } ; robadv2c3      [ Robin's Adventure 2 (Version 1.7SH, set 1) ]
+; { Reason 06 } ; robadv2d1      [ Robin's Adventure 2 (Version 1.7R, set 2) ]
+; { Reason 06 } ; robadv2d2      [ Robin's Adventure 2 (Version 1.7LT, set 2) ]
+; { Reason 06 } ; robadv2d3      [ Robin's Adventure 2 (Version 1.7SH, set 2) ]
+; { Reason 06 } ; robadv2o       [ Robin's Adventure 2 (Version 1.5SH) ]
+; { Reason 06 } ; robadv2o2      [ Robin's Adventure 2 (Version 1.5) ]
+; { Reason 06 } ; robadv2v1      [ Robin's Adventure 2 (Version 1.7R Dual) ]
+; { Reason 06 } ; robadv2v2      [ Robin's Adventure 2 (Version 1.7LT Dual) ]
+; { Reason 06 } ; robadv2v3      [ Robin's Adventure 2 (Version 1.7SH Dual) ]
+; { Reason 06 } ; robadvc1       [ Robin's Adventure (Version 1.7R, set 1) ]
+; { Reason 06 } ; robadvd1       [ Robin's Adventure (Version 1.7R, set 2) ]
+; { Reason 06 } ; robadvo        [ Robin's Adventure (Version 1.5) ]
+; { Reason 06 } ; robadvv1       [ Robin's Adventure (Version 1.7R Dual) ]
+; { Reason 06 } ; rollfr_2       [ Roll Fruit (040318) ]
+; { Reason 06 } ; roul           [ Super Lucky Roulette ]
+; { Reason 06 } ; royalcrd       [ Royal Card (Austrian, set 1) ]
+; { Reason 06 } ; royalcrda      [ Royal Card (Austrian, set 2) ]
+; { Reason 06 } ; royalcrdb      [ Royal Card (Austrian/Polish, set 3) ]
+; { Reason 06 } ; royalcrdc      [ Royal Card (Austrian, set 4) ]
+; { Reason 06 } ; royalcrdd      [ Royal Card (Austrian, set 5) ]
+; { Reason 06 } ; royalcrde      [ Royal Card (Austrian, set 6) ]
+; { Reason 06 } ; royalcrdf      [ Royal Card (Slovak, encrypted) ]
+; { Reason 06 } ; royalcrdp      [ Royal Card v2.0 Professional ]
+; { Reason 06 } ; royale         [ Royale (set 1) ]
+; { Reason 06 } ; royalea        [ Royale (set 2) ]
+; { Reason 06 } ; royalngt       [ Royal Night [BET] (Japan 840220 RN 2-00) ]
+; { Reason 06 } ; roypok96       [ Royal Poker '96 (set 1) ]
+; { Reason 06 } ; roypok96a      [ Royal Poker '96 (set 2) ]
+; { Reason 06 } ; roypok96b      [ Royal Poker '96 (set 3) ]
+; { Reason 06 } ; scherrym       [ Super Cherry Master ]
+; { Reason 06 } ; schery97       [ Skill Cherry '97 (ver. sc3.52) ]
+; { Reason 06 } ; schery97a      [ Skill Cherry '97 (ver. sc3.52c4) ]
+; { Reason 06 } ; seawld         [ Sea World (Version 1.6E Dual) ]
+; { Reason 06 } ; seawldd1       [ Sea World (Version 1.6R CGA) ]
+; { Reason 06 } ; secondch       [ Second Chance ]
+; { Reason 06 } ; setaroul       [ Seta / Visco Roulette? ]
+; { Reason 06 } ; sfbonus        [ Skill Fruit Bonus (Version 1.9R, set 1) ]
+; { Reason 06 } ; sfbonusd1      [ Skill Fruit Bonus (Version 1.9R, set 2) ]
+; { Reason 06 } ; sfbonuso       [ Skill Fruit Bonus (Version 1.7) ]
+; { Reason 06 } ; sfbonuso2      [ Skill Fruit Bonus (Version 1.6) ]
+; { Reason 06 } ; sfbonusv1      [ Skill Fruit Bonus (Version 1.9R Dual) ]
+; { Reason 06 } ; sfruitb        [ Super Fruit Bonus (Version 2.5E Dual) ]
+; { Reason 06 } ; sfruitbb1      [ Super Fruit Bonus (Version 2.5R, set 1) ]
+; { Reason 06 } ; sfruitbb2      [ Super Fruit Bonus (Version 2.0LT, set 1) ]
+; { Reason 06 } ; sfruitbbh      [ Super Fruit Bonus (Version 2.2B, set 1) ]
+; { Reason 06 } ; sfruitbd1      [ Super Fruit Bonus (Version 2.5R, set 2) ]
+; { Reason 06 } ; sfruitbd2      [ Super Fruit Bonus (Version 2.0LT, set 2) ]
+; { Reason 06 } ; sfruitbdh      [ Super Fruit Bonus (Version 2.2B, set 2) ]
+; { Reason 06 } ; sfruitbh       [ Super Fruit Bonus (Version 2.2EB Dual) ]
+; { Reason 06 } ; sfruitbo       [ Super Fruit Bonus (Version 2.0) ]
+; { Reason 06 } ; sfruitbo2      [ Super Fruit Bonus (Version 1.80XT) ]
+; { Reason 06 } ; sfruitboh      [ Super Fruit Bonus (Version 2.0B) ]
+; { Reason 06 } ; sfruitbv1      [ Super Fruit Bonus (Version 2.5R Dual) ]
+; { Reason 06 } ; sfruitbv2      [ Super Fruit Bonus (Version 2.0LT Dual) ]
+; { Reason 06 } ; sfruitbvh      [ Super Fruit Bonus (Version 2.2B Dual) ]
+; { Reason 06 } ; sharkpye       [ Shark Party (English, Alpha license) ]
+; { Reason 06 } ; showhanc       [ Wang Pai Dui Jue ]
+; { Reason 06 } ; showhand       [ Show Hand (Italy) ]
+; { Reason 06 } ; sigma2k        [ Sigma Poker 2000 ]
+; { Reason 06 } ; sigmapkr       [ Sigma Poker ]
+; { Reason 06 } ; sjcd2kx3       [ Super Joly 2000 - 3x ]
+; { Reason 06 } ; skilldrp       [ Skill Drop Georgia ]
+; { Reason 06 } ; skylncr        [ Sky Lancer (Bordun, ver.U450C) ]
+; { Reason 06 } ; sloco93        [ Super Loco 93 (Spanish, set 1) ]
+; { Reason 06 } ; sloco93a       [ Super Loco 93 (Spanish, set 2) ]
+; { Reason 06 } ; slotcarn       [ Slot Carnival ]
+; { Reason 06 } ; snookr10       [ Snooker 10 (Ver 1.11) ]
+; { Reason 06 } ; speeddrp       [ Speed Drop ]
+; { Reason 06 } ; spitboss       [ Super Pit Boss ]
+; { Reason 06 } ; spk115it       [ Super Poker (v115IT) ]
+; { Reason 06 } ; spk116it       [ Super Poker (v116IT) ]
+; { Reason 06 } ; spool99        [ Super Pool 99 (Version 0.36) ]
+; { Reason 06 } ; spool99a       [ Super Pool 99 (Version 0.31) ]
+; { Reason 06 } ; spotty         [ Spotty (Ver. 2.0.2) ]
+; { Reason 06 } ; ssjkrpkr       [ Southern Systems Joker Poker ]
+; { Reason 06 } ; statusbj       [ Status Black Jack (V1.0c) ]
+; { Reason 06 } ; stisub         [ Treasure Bonus (Subsino) ]
+; { Reason 06 } ; supdrapo       [ Super Draw Poker (set 1) ]
+; { Reason 06 } ; supdrapoa      [ Super Draw Poker (set 2) ]
+; { Reason 06 } ; supdrapob      [ Super Draw Poker (bootleg) ]
+; { Reason 06 } ; suprpokr       [ Super Poker ]
+; { Reason 06 } ; sureshot       [ Sure Shot ]
+; { Reason 06 } ; sweetl         [ Sweet Life (041220) ]
+; { Reason 06 } ; sweetla        [ Sweet Life (041220, backdoor) ]
+; { Reason 06 } ; sweetlb        [ Sweet Life (041220, banking address hack, changed version text) ]
+; { Reason 06 } ; tdpgal         [ Triple Draw Poker ]
+; { Reason 06 } ; tighook        [ Tiger Hook (Version 2.1E Dual) ]
+; { Reason 06 } ; tighookc1      [ Tiger Hook (Version 2.1R, set 1) ]
+; { Reason 06 } ; tighookc2      [ Tiger Hook (Version 2.0LT, set 1) ]
+; { Reason 06 } ; tighookd1      [ Tiger Hook (Version 2.1R, set 2) ]
+; { Reason 06 } ; tighookd2      [ Tiger Hook (Version 2.0LT, set 2) ]
+; { Reason 06 } ; tighooko       [ Tiger Hook (Version 1.7XT) ]
+; { Reason 06 } ; tighooko2      [ Tiger Hook (Version 1.7) ]
+; { Reason 06 } ; tighookv1      [ Tiger Hook (Version 2.1R Dual) ]
+; { Reason 06 } ; tighookv2      [ Tiger Hook (Version 2.0LT Dual) ]
+; { Reason 06 } ; tisub          [ Treasure Island (Subsino, set 1) ]
+; { Reason 06 } ; tisuba         [ Treasure Island (Subsino, set 2) ]
+; { Reason 06 } ; tjumpman       [ Tobikose! Jumpman ]
+; { Reason 06 } ; tortufam       [ Tortuga Family (Italian) ]
+; { Reason 06 } ; tour4000       [ Tour 4000 ]
+; { Reason 06 } ; tour4010       [ Tour 4010 ]
+; { Reason 06 } ; tpoker2        [ Turbo Poker 2 ]
+; { Reason 06 } ; vcarn          [ Video Carnival 1999 / Super Royal Card (Version 0.11) ]
+; { Reason 06 } ; vegasfst       [ Royal Vegas Joker Card (fast deal) ]
+; { Reason 06 } ; vegasfte       [ Royal Vegas Joker Card (fast deal, English gfx) ]
+; { Reason 06 } ; vegasmil       [ Royal Vegas Joker Card (fast deal, Mile) ]
+; { Reason 06 } ; vegasslw       [ Royal Vegas Joker Card (slow deal) ]
+; { Reason 06 } ; victor5        [ G.E.A. ]
+; { Reason 06 } ; videomat       [ Videomat (Polish bootleg) ]
+; { Reason 06 } ; witchcda       [ Witch Card (Spanish, witch game, set 1) ]
+; { Reason 06 } ; witchcdb       [ Witch Card (Spanish, witch game, set 2) ]
+; { Reason 06 } ; witchcdc       [ Witch Card (English, no witch game) ]
+; { Reason 06 } ; witchcdd       [ Witch Card (German, set 1) ]
+; { Reason 06 } ; witchcde       [ Witch Card (German, set 2) ]
+; { Reason 06 } ; witchcdf       [ Witch Card (English, witch game, lamps) ]
+; { Reason 06 } ; witchcrd       [ Witch Card (Video Klein) ]
+; { Reason 06 } ; wldarrow       [ Wild Arrow (Standard V4.8) ]
+; { Reason 07 } ; cbombers       [ Chase Bombers ]
+; { Reason 09 } ; carnevil       [ CarnEvil (v1.0.3) ]
+; { Reason 09 } ; crusnwld17     [ Cruis'n World (rev L1.7) ]
+; { Reason 09 } ; ftimpactj      [ Fighters' Impact (Ver 2.02J) ]
+; { Reason 09 } ; lohtb2         [ Legend of Hero Tonma (bootleg, set 2) ]
+; { Reason 09 } ; mk3p40         [ Mortal Kombat 3 (rev 1 chip label p4.0) ]
+; { Reason 09 } ; mkprot8        [ Mortal Kombat (prototype, rev 8.0 07/21/92) ]
+; { Reason 09 } ; pitfight5      [ Pit Fighter (rev 5) ]
+; { Reason 09 } ; policetr13a    [ Police Trainer (Rev 1.3B Newer) ]
+; { Reason 09 } ; soulclbrb      [ Soul Calibur (SOC14/VER.B) ]
+; { Reason 09 } ; soulclbrb2     [ Soul Calibur (SOC13/VER.B) ]
+; { Reason 09 } ; soulclbrja     [ Soul Calibur (Japan, SOC11/VER.A2) ]
+; { Reason 09 } ; splatter       [ Splatter House (World new version) ]
+; { Reason 09 } ; statriv2v      [ Triv Two (Vertical) ]
+; { Reason 09 } ; surfplnt40     [ Surf Planet (Version 4.0) ]
+; { Reason 09 } ; tengaij        [ Sengoku Blade: Sengoku Ace Episode II / Tengai ]
+; { Reason 09 } ; thndrx2        [ Thunder Cross II (World) ]
+; { Reason 09 } ; tnzsjo         [ The NewZealand Story (Japan, old version) (older PCB) ]
+; { Reason 09 } ; tnzsop         [ The NewZealand Story (World, prototype?) (older PCB) ]
+; { Reason 09 } ; vballb         [ U.S. Championship V'ball (bootleg) ]
+; { Reason 09 } ; volfiedjo      [ Volfied (Japan) ]
+; { Reason 09 } ; wcbowl16       [ World Class Bowling (v1.6) ]
+; { Reason 11 } ; 1on1gov        [ 1 on 1 Government (Japan) ]
+; { Reason 11 } ; alpinesa       [ Alpine Surfer (Rev. AF2 Ver.A) ]
+; { Reason 11 } ; amerdart       [ AmeriDarts (set 1) ]
+; { Reason 11 } ; amerdart2      [ AmeriDarts (set 2) ]
+; { Reason 11 } ; amerdart3      [ AmeriDarts (set 3) ]
+; { Reason 11 } ; amuse          [ Amuse (Version 50.08 IBA) ]
+; { Reason 11 } ; apple10        [ Apple 10 (Ver 1.21) ]
+; { Reason 11 } ; bam2           [ Bust a Move 2 (Japanese ROM ver. 1999/07/17 10:00:00) ]
+; { Reason 11 } ; beautyb        [ Beauty Block ]
+; { Reason 11 } ; bigdeal        [ Big Deal (Hungarian, set 1) ]
+; { Reason 11 } ; bigdealb       [ Big Deal (Hungarian, set 2) ]
+; { Reason 11 } ; bilyard        [ Billiard ]
+; { Reason 11 } ; bm3rdmix       [ beatmania 3rd MIX (ver JA-A) ]
+; { Reason 11 } ; bm7thmix       [ beatmania 7th MIX (ver JA-B) ]
+; { Reason 11 } ; bmcbowl        [ BMC Bowling ]
+; { Reason 11 } ; bmclubmx       [ beatmania Club MIX (ver JA-A) ]
+; { Reason 11 } ; bmfinal        [ beatmania THE FINAL (ver JA-A) ]
+; { Reason 11 } ; bowl3d         [ 3-D Bowling ]
+; { Reason 11 } ; bubbletr       [ Bubble Trouble (Japan) ]
+; { Reason 11 } ; cardline       [ Card Line ]
+; { Reason 11 } ; carrera        [ Carrera (Version 6.7) ]
+; { Reason 11 } ; cashquiz       [ Cash Quiz (Type B, Version 5) ]
+; { Reason 11 } ; cecmatch       [ ChuckECheese's Match Game ]
+; { Reason 11 } ; chainrec       [ Chain Reaction (World, Version 2.2, 1995.09.25) ]
+; { Reason 11 } ; champbwl       [ Championship Bowling ]
+; { Reason 11 } ; chanbara       [ Chanbara ]
+; { Reason 11 } ; colmns97       [ Columns '97 (JET 961209 V1.000) ]
+; { Reason 11 } ; comg175        [ Cal Omega - Game 17.51 (Gaming Draw Poker) ]
+; { Reason 11 } ; coronatn       [ Coronation Street Quiz Game ]
+; { Reason 11 } ; critcrsh       [ Critter Crusher (EA 951204 V1.000) ]
+; { Reason 11 } ; cybrcycc       [ Cyber Cycles (Rev. CB2 Ver.C) ]
+; { Reason 11 } ; dai2kaku       [ Dai-Dai-Kakumei (Japan) ]
+; { Reason 11 } ; daisyari       [ Daisyarin [BET] (Japan) ]
+; { Reason 11 } ; darkhleg       [ Dark Horse Legend (GX706 VER. JAA) ]
+; { Reason 11 } ; darkhors       [ Dark Horse (bootleg of Jockey Club II) ]
+; { Reason 11 } ; dcheese        [ Double Cheese ]
+; { Reason 11 } ; ddealer        [ Double Dealer ]
+; { Reason 11 } ; ddp2           [ Bee Storm - DoDonPachi II (ver. 100) ]
+; { Reason 11 } ; ddr2m          [ Dance Dance Revolution 2nd Mix (GN895 VER. JAA) ]
+; { Reason 11 } ; ddr2mc         [ Dance Dance Revolution 2nd Mix with beatmaniaIIDX CLUB VERSiON (GE896 VER. JAA) ]
+; { Reason 11 } ; ddr2mc2        [ Dance Dance Revolution 2nd Mix with beatmaniaIIDX substream CLUB VERSiON 2 (GE984 VER. JAA) ]
+; { Reason 11 } ; ddr2ml         [ Dance Dance Revolution 2nd Mix - Link Ver (GE885 VER. JAA) ]
+; { Reason 11 } ; ddr3ma         [ Dance Dance Revolution 3rd Mix (GN887 VER. AAA) ]
+; { Reason 11 } ; ddr3mj         [ Dance Dance Revolution 3rd Mix (GN887 VER. JAA) ]
+; { Reason 11 } ; ddr3mk         [ Dance Dance Revolution 3rd Mix - Ver.Korea2 (GN887 VER. KBA) ]
+; { Reason 11 } ; ddr3mka        [ Dance Dance Revolution 3rd Mix - Ver.Korea (GN887 VER. KAA) ]
+; { Reason 11 } ; ddr3mp         [ Dance Dance Revolution 3rd Mix Plus (G*A22 VER. JAA) ]
+; { Reason 11 } ; ddr4m          [ Dance Dance Revolution 4th Mix (G*A33 VER. AAA) ]
+; { Reason 11 } ; ddr4mj         [ Dance Dance Revolution 4th Mix (G*A33 VER. JAA) ]
+; { Reason 11 } ; ddr4mp         [ Dance Dance Revolution 4th Mix Plus (G*A34 VER. JAA) ]
+; { Reason 11 } ; ddr4mps        [ Dance Dance Revolution 4th Mix Plus Solo (G*A34 VER. JAA) ]
+; { Reason 11 } ; ddr4ms         [ Dance Dance Revolution 4th Mix Solo (G*A33 VER. ABA) ]
+; { Reason 11 } ; ddr4msj        [ Dance Dance Revolution 4th Mix Solo (G*A33 VER. JBA) ]
+; { Reason 11 } ; ddr5m          [ Dance Dance Revolution 5th Mix (G*A27 VER. JAA) ]
+; { Reason 11 } ; ddra           [ Dance Dance Revolution (GN845 VER. AAA) ]
+; { Reason 11 } ; ddrbocd        [ Dance Dance Revolution Best of Cool Dancers (GE892 VER. JAA) ]
+; { Reason 11 } ; ddrextrm       [ Dance Dance Revolution Extreme (G*C36 VER. JAA) ]
+; { Reason 11 } ; ddrj           [ Dance Dance Revolution - Internet Ranking Ver (GC845 VER. JBA) ]
+; { Reason 11 } ; ddrja          [ Dance Dance Revolution (GC845 VER. JAA) ]
+; { Reason 11 } ; ddrjb          [ Dance Dance Revolution (GC845 VER. JAB) ]
+; { Reason 11 } ; ddrmax         [ DDR Max - Dance Dance Revolution 6th Mix (G*B19 VER. JAA) ]
+; { Reason 11 } ; ddrmax2        [ DDR Max 2 - Dance Dance Revolution 7th Mix (G*B20 VER. JAA) ]
+; { Reason 11 } ; ddrs2k         [ Dance Dance Revolution Solo 2000 (GC905 VER. AAA) ]
+; { Reason 11 } ; ddrs2kj        [ Dance Dance Revolution Solo 2000 (GC905 VER. JAA) ]
+; { Reason 11 } ; ddrsbm         [ Dance Dance Revolution Solo Bass Mix (GQ894 VER. JAA) ]
+; { Reason 11 } ; ddru           [ Dance Dance Revolution (GN845 VER. UAA) ]
+; { Reason 11 } ; ddrusa         [ Dance Dance Revolution USA (G*A44 VER. UAA) ]
+; { Reason 11 } ; deroon         [ Deroon DeroDero ]
+; { Reason 11 } ; dmx            [ Dance Maniax (G*874 VER. JAA) ]
+; { Reason 11 } ; dmx2m          [ Dance Maniax 2nd Mix (G*A39 VER. JAA) ]
+; { Reason 11 } ; dmx2majp       [ Dance Maniax 2nd Mix Append J-Paradise (G*A38 VER. JAA) ]
+; { Reason 11 } ; dncfrks        [ Dance Freaks (G*874 VER. KAA) ]
+; { Reason 11 } ; dolphin        [ Dolphin Blue ]
+; { Reason 11 } ; dquizgo2       [ Date Quiz Go Go Episode 2 ]
+; { Reason 11 } ; drmn           [ DrumMania (GQ881 VER. JAD) ]
+; { Reason 11 } ; drmn2m         [ DrumMania 2nd Mix (GE912 VER. JAB) ]
+; { Reason 11 } ; drmn2mpu       [ DrumMania 2nd Mix Session Power Up Kit (GE912 VER. JAB) ]
+; { Reason 11 } ; drmn3m         [ DrumMania 3rd Mix (G*A23 VER. JAA) ]
+; { Reason 11 } ; dsem2          [ Dancing Stage Euro Mix 2 (G*C23 VER. EAA) ]
+; { Reason 11 } ; dsfdcta        [ Dancing Stage featuring Dreams Come True (GC910 VER. JAA) ]
+; { Reason 11 } ; dsftkd         [ Dancing Stage featuring TRUE KiSS DESTiNATiON (G*884 VER. JAA) ]
+; { Reason 11 } ; dstage         [ Dancing Stage (GN845 VER. EAA) ]
+; { Reason 11 } ; dwarfd         [ Dwarfs Den ]
+; { Reason 11 } ; dynabb         [ Dynamite Baseball '97 (Revision A) ]
+; { Reason 11 } ; dynashot       [ Dynamic Shooting ]
+; { Reason 11 } ; dynobop        [ Dyno Bop ]
+; { Reason 11 } ; eaglshot       [ Eagle Shot Golf ]
+; { Reason 11 } ; elgrande       [ El Grande - 5 Card Draw (New) ]
+; { Reason 11 } ; escounts       [ Every Second Counts (39-360-053) ]
+; { Reason 11 } ; fghtbskt       [ Fighting Basketball ]
+; { Reason 11 } ; fhboxers       [ Funky Head Boxers (JUETBKAL 951218 V1.000) ]
+; { Reason 11 } ; filetto        [ Filetto (v1.05 901009) ]
+; { Reason 11 } ; finalapr       [ Final Lap R (Rev. B) ]
+; { Reason 11 } ; finalaprj      [ Final Lap R (Japan Rev. C) ]
+; { Reason 11 } ; finalapro      [ Final Lap R ]
+; { Reason 11 } ; fishfren       [ Fishin' Frenzy (prototype) ]
+; { Reason 11 } ; flipmaze       [ Flip Maze (V2.04J) ]
+; { Reason 11 } ; fmaniac3       [ Fishing Maniac 3 ]
+; { Reason 11 } ; fredmem        [ Fred Flintstones' Memory Match (World?, Ticket version, 3/17/95) ]
+; { Reason 11 } ; fredmemc       [ Fred Flintstones' Memory Match (Mandarin Chinese, 3/17/95) ]
+; { Reason 11 } ; fredmemj       [ Fred Flintstones' Memory Match (Japan, High Score version, 3/20/95) ]
+; { Reason 11 } ; fredmemuk      [ Fred Flintstones' Memory Match (UK, 3/17/95) ]
+; { Reason 11 } ; fredmemus      [ Fred Flintstones' Memory Match (US, High Score version, 3/10/95) ]
+; { Reason 11 } ; fredmesp       [ Fred Flintstones' Memory Match (Spanish, 3/17/95) ]
+; { Reason 11 } ; freezeat       [ Freeze (Atari) (prototype, English voice, 96/10/25) ]
+; { Reason 11 } ; freezeat2      [ Freeze (Atari) (prototype, 96/10/18) ]
+; { Reason 11 } ; freezeat3      [ Freeze (Atari) (prototype, 96/10/07) ]
+; { Reason 11 } ; freezeat4      [ Freeze (Atari) (prototype, 96/10/03) ]
+; { Reason 11 } ; freezeat5      [ Freeze (Atari) (prototype, 96/09/20, AMOA-96) ]
+; { Reason 11 } ; freezeat6      [ Freeze (Atari) (prototype, 96/09/07, Jamma-96) ]
+; { Reason 11 } ; freezeatjp     [ Freeze (Atari) (prototype, Japanese voice, 96/10/25) ]
+; { Reason 11 } ; funcube2       [ Funcube 2 (v1.1) ]
+; { Reason 11 } ; funcube4       [ Funcube 4 (v1.0) ]
+; { Reason 11 } ; funkyfig       [ The First Funky Fighter ]
+; { Reason 11 } ; galgame2       [ Galaxy Games StarPak 2 ]
+; { Reason 11 } ; galpani3       [ Gals Panic 3 ]
+; { Reason 11 } ; gekisou        [ Gekisou (Japan) ]
+; { Reason 11 } ; gepoker        [ Poker (Version 50.02 ICB, set 1) ]
+; { Reason 11 } ; gepoker1       [ Poker (Version 50.02 ICB, set 2) ]
+; { Reason 11 } ; gepoker2       [ Poker (Version 50.02 ICB, set 3) ]
+; { Reason 11 } ; ghoshunt       [ Ghost Hunter ]
+; { Reason 11 } ; girotutt       [ GiroTutto ]
+; { Reason 11 } ; gldncrwn       [ Golden Crown (Dutch, Game Card 95-752-011) ]
+; { Reason 11 } ; glpracr        [ Gallop Racer (Japan Ver 9.01.12) ]
+; { Reason 11 } ; glpracr3       [ Gallop Racer 3 (Japan) ]
+; { Reason 11 } ; good           [ Good (Korea) ]
+; { Reason 11 } ; greatgun       [ Great Guns ]
+; { Reason 11 } ; grmatch        [ Grudge Match (Yankee Game Technology) ]
+; { Reason 11 } ; gs4002         [ Selection (Version 40.02TMB, set 1) ]
+; { Reason 11 } ; gs4002a        [ Selection (Version 40.02TMB, set 2) ]
+; { Reason 11 } ; gtfrk11m       [ Guitar Freaks 11th Mix (G*D39 VER. JAA) ]
+; { Reason 11 } ; gtrfrk3m       [ Guitar Freaks 3rd Mix (GE949 VER. JAC) ]
+; { Reason 11 } ; gtrfrk4m       [ Guitar Freaks 4th Mix (G*A24 VER. JAA) ]
+; { Reason 11 } ; gtrfrk5m       [ Guitar Freaks 5th Mix (G*A26 VER. JAA) ]
+; { Reason 11 } ; gtrfrks        [ Guitar Freaks (GQ886 VER. EAC) ]
+; { Reason 11 } ; gtrfrksa       [ Guitar Freaks (GQ886 VER. AAC) ]
+; { Reason 11 } ; gtrfrksj       [ Guitar Freaks (GQ886 VER. JAC) ]
+; { Reason 11 } ; gtrfrksu       [ Guitar Freaks (GQ886 VER. UAC) ]
+; { Reason 11 } ; guab           [ Give us a Break (3rd edition) ]
+; { Reason 11 } ; guab21         [ Give us a Break (21st edition) ]
+; { Reason 11 } ; guab3a         [ Give us a Break (3rd edition alt?) ]
+; { Reason 11 } ; guab4          [ Give us a Break (4th edition) ]
+; { Reason 11 } ; guab43         [ Give us a Break (43rd edition) ]
+; { Reason 11 } ; guab6          [ Give us a Break (6th edition) ]
+; { Reason 11 } ; guab6a         [ Give us a Break (6th edition alt?) ]
+; { Reason 11 } ; guab7          [ Give us a Break (7th edition) ]
+; { Reason 11 } ; guts           [ Guts n' Glory (prototype) ]
+; { Reason 11 } ; hanagumi       [ Hanagumi Taisen Columns - Sakura Wars (J 971007 V1.010) ]
+; { Reason 11 } ; hanakanz       [ Hana Kanzashi (Japan) ]
+; { Reason 11 } ; hangman        [ Hangman ]
+; { Reason 11 } ; hayaosi1       [ Hayaoshi Quiz Ouza Ketteisen - The King Of Quiz ]
+; { Reason 11 } ; hayaosi2       [ Hayaoshi Quiz Grand Champion Taikai ]
+; { Reason 11 } ; hayaosi3       [ Hayaoshi Quiz Nettou Namahousou ]
+; { Reason 11 } ; hdrivair       [ Hard Drivin's Airborne (prototype) ]
+; { Reason 11 } ; hdrivairp      [ Hard Drivin's Airborne (prototype, early rev) ]
+; { Reason 11 } ; himesiki       [ Himeshikibu (Japan) ]
+; { Reason 11 } ; hngmnjpm       [ Hangman (JPM) ]
+; { Reason 11 } ; homerun        [ Moero Pro Yakyuu Homerun ]
+; { Reason 11 } ; hotmind        [ Hot Mind ]
+; { Reason 11 } ; hotminda       [ Hot Mind (adjustable prize) ]
+; { Reason 11 } ; hotsmash       [ Vs. Hot Smash ]
+; { Reason 11 } ; hyperbbc       [ Hyper Bishi Bashi Champ (GX908 1999/08/24 VER. JAA) ]
+; { Reason 11 } ; hyperbbck      [ Hyper Bishi Bashi Champ (GX908 1999/08/24 VER. KAA) ]
+; { Reason 11 } ; hyprdriv       [ Hyperdrive ]
+; { Reason 11 } ; indytempc      [ Indiana Jones and the Temple of Doom (Cocktail) ]
+; { Reason 11 } ; intlaser       [ International Team Laser (prototype) ]
+; { Reason 11 } ; island         [ Island (050713) ]
+; { Reason 11 } ; jackie         [ Happy Jackie (v110U) ]
+; { Reason 11 } ; jangou         [ Jangou [BET] (Japan) ]
+; { Reason 11 } ; jjpoker        [ Jackpot Joker Poker (set 1) ]
+; { Reason 11 } ; jjpokerb       [ Jackpot Joker Poker (set 2) ]
+; { Reason 11 } ; jmpbreak       [ Jumping Break ]
+; { Reason 11 } ; jockeygp       [ Jockey Grand Prix ]
+; { Reason 11 } ; jollycrd       [ Jolly Card (Austrian) ]
+; { Reason 11 } ; jolyccra       [ Jolly Card (Croatian, set 1) ]
+; { Reason 11 } ; jolyccrb       [ Jolly Card (Croatian, set 2) ]
+; { Reason 11 } ; jolycdat       [ Jolly Card (Austrian, Funworld) ]
+; { Reason 11 } ; jsk            [ Joryuu Syougi Kyoushitsu (Japan) ]
+; { Reason 11 } ; kbm2nd         [ Keyboardmania 2nd Mix ]
+; { Reason 11 } ; keroppi        [ Kero Kero Keroppi no Issyoni Asobou (Japan) ]
+; { Reason 11 } ; killbldp       [ The Killing Blade Plus (ver. 300) ]
+; { Reason 11 } ; kingpin        [ King Pin ]
+; { Reason 11 } ; kingpinm       [ King Pin Multi-Game ]
+; { Reason 11 } ; kiwames        [ Pro Mahjong Kiwame S (J 951020 V1.208) ]
+; { Reason 11 } ; kollon         [ Kollon (V2.04J) ]
+; { Reason 11 } ; kollonc        [ Kollon (V2.04JC) ]
+; { Reason 11 } ; koroleva       [ Snezhnaja Koroleva ]
+; { Reason 11 } ; kothello       [ Kyuukyoku no Othello ]
+; { Reason 11 } ; kov7sprt       [ Knights of Valour - The Seven Spirits ]
+; { Reason 11 } ; kovsh          [ Knights of Valour Super Heroes / Sangoku Senki Super Heroes (ver. 104, CN) ]
+; { Reason 11 } ; kovsh103       [ Knights of Valour Super Heroes / Sangoku Senki Super Heroes (ver. 103, CN) ]
+; { Reason 11 } ; kovshp         [ Knights of Valour Super Heroes Plus / Sangoku Senki Super Heroes Plus (ver. 100) ]
+; { Reason 11 } ; ladylinr       [ Lady Liner ]
+; { Reason 11 } ; landmakrp      [ Land Maker (Ver 2.02O 1998/06/02) (Prototype) ]
+; { Reason 11 } ; lasstixx       [ Laser Strixx 2 ]
+; { Reason 11 } ; lasvegas       [ Las Vegas, Nevada ]
+; { Reason 11 } ; lottof2        [ Lotto Fun 2 ]
+; { Reason 11 } ; luctoday       [ Lucky Today ]
+; { Reason 11 } ; luplup         [ Lup Lup Puzzle / Zhuan Zhuan Puzzle (version 3.0 / 990128) ]
+; { Reason 11 } ; luplup29       [ Lup Lup Puzzle / Zhuan Zhuan Puzzle (version 2.9 / 990108) ]
+; { Reason 11 } ; macha          [ Monoshiri Quiz Osyaberi Macha (Japan) ]
+; { Reason 11 } ; machbrkr       [ Mach Breakers - Numan Athletics 2 (Japan) ]
+; { Reason 11 } ; magdrop        [ Magical Drop (Japan, Version 1.1, 1995.06.21) ]
+; { Reason 11 } ; magdropp       [ Magical Drop Plus 1 (Japan, Version 2.1, 1995.09.12) ]
+; { Reason 11 } ; magic10        [ Magic's 10 (ver. 16.55) ]
+; { Reason 11 } ; magic10a       [ Magic's 10 (ver. 16.45) ]
+; { Reason 11 } ; magic10b       [ Magic's 10 (ver. 16.15) ]
+; { Reason 11 } ; magicfly       [ Magic Fly ]
+; { Reason 11 } ; magicstk       [ Magic Sticks ]
+; { Reason 11 } ; mainsnk        [ Main Event (1984) ]
+; { Reason 11 } ; makaijan       [ Makaijan [BET] (Japan) ]
+; { Reason 11 } ; mastboy        [ Master Boy (Spanish, PCB Rev A) ]
+; { Reason 11 } ; mastboyi       [ Master Boy (Italian, PCB Rev A) ]
+; { Reason 11 } ; match98        [ Match '98 (ver. 1.33) ]
+; { Reason 11 } ; maverik        [ Maverik ]
+; { Reason 11 } ; mayjisn2       [ Mayjinsen 2 ]
+; { Reason 11 } ; megat3         [ Megatouch III (9255-20-01 RON, Standard version) ]
+; { Reason 11 } ; megat3a        [ Megatouch III (9255-20-01 ROF, Standard version) ]
+; { Reason 11 } ; megat3ca       [ Megatouch III (9255-20-06 RON, California version) ]
+; { Reason 11 } ; megat3nj       [ Megatouch III (9255-20-07 ROG, New Jersey version) ]
+; { Reason 11 } ; megat3te       [ Megatouch III Tournament Edition (9255-30-01 ROE, Standard version) ]
+; { Reason 11 } ; megat4         [ Megatouch IV (9255-40-01 ROE, Standard version) ]
+; { Reason 11 } ; megat4a        [ Megatouch IV (9255-40-01 ROD, Standard version) ]
+; { Reason 11 } ; megat4sn       [ Super Megatouch IV (9255-41-07 ROG, New Jersey version) ]
+; { Reason 11 } ; megat4st       [ Super Megatouch IV Tournament Edition (9255-51-01 ROB, Standard version) ]
+; { Reason 11 } ; megat4te       [ Megatouch IV Tournament Edition (9255-50-01 ROD, Standard version) ]
+; { Reason 11 } ; megat4tea      [ Megatouch IV Tournament Edition (9255-50-01 ROA, Standard version) ]
+; { Reason 11 } ; megat5         [ Megatouch 5 (9255-60-01 ROI, Standard version) ]
+; { Reason 11 } ; megat5nj       [ Megatouch 5 (9255-60-07 RON, New Jersey version) ]
+; { Reason 11 } ; megat6         [ Megatouch 6 (9255-80-01 ROA, Standard version) ]
+; { Reason 11 } ; meijinsn       [ Meijinsen ]
+; { Reason 11 } ; mf_brist       [ Bristles (Max-A-Flex) ]
+; { Reason 11 } ; mf_flip        [ Flip & Flop (Max-A-Flex) ]
+; { Reason 11 } ; mineswpr4      [ Minesweeper (4-Player) ]
+; { Reason 11 } ; mmpanic        [ Monkey Mole Panic (USA) ]
+; { Reason 11 } ; mogura         [ Mogura Desse (Japan) ]
+; { Reason 11 } ; mosaicf2       [ Mosaic (F2 System) ]
+; { Reason 11 } ; motoxgo        [ Motocross Go! (MG3 Ver. A) ]
+; { Reason 11 } ; mp_col3        [ Columns III (Mega Play) ]
+; { Reason 11 } ; mp_gslam       [ Grand Slam (Mega Play) ]
+; { Reason 11 } ; mt_parlg       [ Parlour Games (Mega-Tech, SMS based) ]
+; { Reason 11 } ; mt_shang       [ Super Hang-On (Mega-Tech) ]
+; { Reason 11 } ; mt_smgp        [ Super Monaco GP (Mega-Tech) ]
+; { Reason 11 } ; mt_srbb        [ Super Real Basketball (Mega-Tech) ]
+; { Reason 11 } ; mt_stf         [ Joe Montana II: Sports Talk Football (Mega-Tech) ]
+; { Reason 11 } ; mt_tetri       [ Tetris (Mega-Tech) ]
+; { Reason 11 } ; mt_wwar        [ Wrestle War (Mega-Tech) ]
+; { Reason 11 } ; mv4in1         [ Mini Vegas 4in1 ]
+; { Reason 11 } ; nagano98       [ Nagano Winter Olympics '98 (GX720 EAA) ]
+; { Reason 11 } ; nbapbp         [ NBA Play By Play ]
+; { Reason 11 } ; newmcard       [ New Magic Card ]
+; { Reason 11 } ; nss_skin       [ Skins Game (Nintendo Super System) ]
+; { Reason 11 } ; nss_sten       [ Super Tennis (Nintendo Super System) ]
+; { Reason 11 } ; oldsplus       [ Oriental Legend Special Plus / Xi You Shi E Zhuan Super Plus ]
+; { Reason 11 } ; opwolfj        [ Operation Wolf (Japan) ]
+; { Reason 11 } ; orlegend105k   [ Oriental Legend / Xi You Shi E Zhuan (ver. 105, Korean Board) ]
+; { Reason 11 } ; orlegend111c   [ Oriental Legend / Xi You Shi E Zhuan (ver. 111, Chinese Board) ]
+; { Reason 11 } ; orlegendca     [ Oriental Legend / Xi You Shi E Zhuan (ver. ???, Chinese Board) ]
+; { Reason 11 } ; otenamhf       [ Otenami Haiken Final (V2.07JC) ]
+; { Reason 11 } ; otenki         [ Otenki Kororin (V2.01J) ]
+; { Reason 11 } ; othello        [ Othello (version 3.0) ]
+; { Reason 11 } ; pacapp         [ Paca Paca Passion (Japan, PPP1/VER.A2) ]
+; { Reason 11 } ; pacapp2        [ Paca Paca Passion 2 (Japan, PKS1/VER.A) ]
+; { Reason 11 } ; pacappsp       [ Paca Paca Passion Special (Japan, PSP1/VER.A) ]
+; { Reason 11 } ; pairlove       [ Pairs Love ]
+; { Reason 11 } ; para2dx        [ Paradise 2 Deluxe ]
+; { Reason 11 } ; paradice       [ Paradice (Dutch, Game Card 95-750-615) ]
+; { Reason 11 } ; pasha2         [ Pasha Pasha 2 ]
+; { Reason 11 } ; pbballex       [ Powerful Pro Baseball EX (GX802 VER. JAB) ]
+; { Reason 11 } ; pblbeach       [ Pebble Beach - The Great Shot (JUE 950913 V0.990) ]
+; { Reason 11 } ; pcnfrk3m       [ Percussion Freaks 3rd Mix (G*A23 VER. KAA) ]
+; { Reason 11 } ; pc_pinbt       [ PinBot (PlayChoice-10) ]
+; { Reason 11 } ; pesadelo       [ Pesadelo (bootleg of Knightmare on MSX) ]
+; { Reason 11 } ; phklad         [ Klad / Labyrinth (Photon System) ]
+; { Reason 11 } ; photoy2k       [ Photo Y2K (ver. 105) ]
+; { Reason 11 } ; photoy2k102    [ Photo Y2K (ver. 102, Japanese Board) ]
+; { Reason 11 } ; photoy2k104    [ Photo Y2K (ver. 104) ]
+; { Reason 11 } ; phrcraze       [ Phraze Craze (set 1) ]
+; { Reason 11 } ; phrcrazea      [ Phraze Craze (set 2) ]
+; { Reason 11 } ; phrcrazeb      [ Phraze Craze (Expanded Questions, set 1) ]
+; { Reason 11 } ; phrcrazec      [ Phraze Craze (Expanded Questions, set 2) ]
+; { Reason 11 } ; phrcrazev      [ Phraze Craze (Sex Kit, Vertical) ]
+; { Reason 11 } ; phtetris       [ Tetris (Photon System) ]
+; { Reason 11 } ; pitbossm       [ Pit Boss Megastar (9244-00-01) ]
+; { Reason 11 } ; pitbossma      [ Pit Boss Megastar (9243-00-01) ]
+; { Reason 11 } ; pkgnsh         [ Pachinko Gindama Shoubu (Japan) ]
+; { Reason 11 } ; pkgnshdx       [ Pachinko Gindama Shoubu DX (Japan) ]
+; { Reason 11 } ; pkscram        [ PK Scramble ]
+; { Reason 11 } ; pktet346       [ PK Tetris (v346I) ]
+; { Reason 11 } ; pntnpuzl       [ Paint & Puzzle ]
+; { Reason 11 } ; pnyaa          [ Pochi and Nyaa ]
+; { Reason 11 } ; poker41        [ Poker 4-1 ]
+; { Reason 11 } ; pokio          [ Pokio (Dutch, Game Card 95-750-278) ]
+; { Reason 11 } ; pokrdice       [ Poker Dice ]
+; { Reason 11 } ; ponttehk       [ Pontoon (Tehkan) ]
+; { Reason 11 } ; popbingo       [ Pop Bingo ]
+; { Reason 11 } ; popn2          [ Pop'n Music 2 (ver JA-A) ]
+; { Reason 11 } ; popn7          [ Pop n' Music 7 ]
+; { Reason 11 } ; potgame        [ Pot Game (Italian) ]
+; { Reason 11 } ; ppd            [ ParaParaDancing ]
+; { Reason 11 } ; ppking         [ Ping-Pong King ]
+; { Reason 11 } ; ppmast93       [ Ping Pong Masters '93 ]
+; { Reason 11 } ; ppp11          [ ParaParaParadise v1.1 ]
+; { Reason 11 } ; progolf        [ 18 Holes Pro Golf (set 1) ]
+; { Reason 11 } ; progolfa       [ 18 Holes Pro Golf (set 2) ]
+; { Reason 11 } ; promutrv       [ Progressive Music Trivia (Question set 1) ]
+; { Reason 11 } ; promutrva      [ Progressive Music Trivia (Question set 2) ]
+; { Reason 11 } ; promutrvb      [ Progressive Music Trivia (Question set 3) ]
+; { Reason 11 } ; promutrvc      [ Progressive Music Trivia (Question set 4) ]
+; { Reason 11 } ; prosoccr       [ Pro Soccer ]
+; { Reason 11 } ; prosport       [ Pro Sports - Bowling, Tennis, and Golf ]
+; { Reason 11 } ; prosporta      [ Pro Sports - Bowling, Tennis, and Golf (alternate) ]
+; { Reason 11 } ; protennb       [ Tennis (bootleg of Pro Tennis) ]
+; { Reason 11 } ; psyvarrv       [ Psyvariar -Revision- (V2.04J) ]
+; { Reason 11 } ; pulltabs       [ Pull Tabs ]
+; { Reason 11 } ; puzlbang       [ Puzzle Bang Bang (Korea, version 2.8 / 990106) ]
+; { Reason 11 } ; puzlstar       [ Puzzle Star (ver. 100MG) ]
+; { Reason 11 } ; puzzlekg       [ Puzzle King (Dance & Puzzle) ]
+; { Reason 11 } ; puzzloopa      [ Puzz Loop (Asia) ]
+; { Reason 11 } ; pyramid        [ Pyramid (Dutch, Game Card 95-750-898) ]
+; { Reason 11 } ; pzletime       [ Puzzle Time (prototype) ]
+; { Reason 11 } ; qntoond        [ Quintoon (Dutch, Game Card 95-750-243) ]
+; { Reason 11 } ; qntoondo       [ Quintoon (Dutch, Game Card 95-750-136) ]
+; { Reason 11 } ; quintono       [ Quintoon (UK, Game Card 95-750-203) ]
+; { Reason 11 } ; quintoon       [ Quintoon (UK, Game Card 95-750-206) ]
+; { Reason 11 } ; quiz           [ Quiz (Revision 2) ]
+; { Reason 11 } ; quiz211        [ Quiz (Revision 2.11) ]
+; { Reason 11 } ; quizo          [ Quiz Olympic (set 1) ]
+; { Reason 11 } ; quizoa         [ Quiz Olympic (set 2) ]
+; { Reason 11 } ; quizvadr       [ Quizvaders (39-360-078) ]
+; { Reason 11 } ; racingb        [ Racing Beat (World) ]
+; { Reason 11 } ; rcasino        [ Royal Casino ]
+; { Reason 11 } ; rclimb_3       [ Rock Climber (040827) ]
+; { Reason 11 } ; re900          [ Ruleta RE-900 ]
+; { Reason 11 } ; rockn2         [ Rock'n Tread 2 (Japan) ]
+; { Reason 11 } ; rocknms        [ Rock'n MegaSession (Japan) ]
+; { Reason 11 } ; rumblef        [ The Rumble Fish ]
+; { Reason 11 } ; saklove        [ Ying Hua Lian 2.0 (China 1.02) ]
+; { Reason 11 } ; salarymc       [ Salary Man Champ (GCA18 VER. JAA) ]
+; { Reason 11 } ; sanjeon        [ DaeJeon! SanJeon SuJeon (AJTUE 990412 V1.000) ]
+; { Reason 11 } ; sasissu        [ Taisen Tanto-R Sashissu!! (J 980216 V1.000) ]
+; { Reason 11 } ; scud           [ Scud Race (Australia) ]
+; { Reason 11 } ; scuda          [ Scud Race (Export) ]
+; { Reason 11 } ; scudp          [ Scud Race Plus (Revision A) ]
+; { Reason 11 } ; sderby         [ Super Derby ]
+; { Reason 11 } ; sdtennis       [ Super Doubles Tennis ]
+; { Reason 11 } ; semibase       [ MuHanSeungBu (SemiCom Baseball) (Korea) ]
+; { Reason 11 } ; sfchamp        [ Super Football Champ (Ver 2.5O) ]
+; { Reason 11 } ; sfchamp24o     [ Super Football Champ (Ver 2.4O) ]
+; { Reason 11 } ; sfchampj       [ Super Football Champ (Ver 2.4J) ]
+; { Reason 11 } ; sfkick         [ Super Free Kick (set 1) ]
+; { Reason 11 } ; sfkicka        [ Super Free Kick (set 2) ]
+; { Reason 11 } ; sfrush         [ San Francisco Rush ]
+; { Reason 11 } ; sfrushrk       [ San Francisco Rush: The Rock ]
+; { Reason 11 } ; sgsafari       [ Super Gran Safari (ver 3.11) ]
+; { Reason 11 } ; shanghss       [ Shanghai Shoryu Sairin (V2.03J) ]
+; { Reason 11 } ; sianniv        [ Space Invaders Anniversary (V2.02J) ]
+; { Reason 11 } ; sidebs2        [ Side By Side 2 (North/South America) ]
+; { Reason 11 } ; sidebs2j       [ Side By Side 2 (Japan) ]
+; { Reason 11 } ; skill98        [ Skill '98 (ver. s98-1.33) ]
+; { Reason 11 } ; slotsnl        [ Slots (Dutch, Game Card 95-750-368) ]
+; { Reason 11 } ; sltblgp1       [ Slots (Belgian Cash, Game Card 95-752-008) ]
+; { Reason 11 } ; sltblgpo       [ Slots (Belgian Cash, Game Card 95-750-938) ]
+; { Reason 11 } ; sltblgtk       [ Slots (Belgian Token, Game Card 95-750-943) ]
+; { Reason 11 } ; smleague       [ Super Major League (U 960108 V1.000) ]
+; { Reason 11 } ; sosterm        [ S.O.S. ]
+; { Reason 11 } ; sothello       [ Super Othello ]
+; { Reason 11 } ; soutenry       [ Soutenryu (V2.07J) ]
+; { Reason 11 } ; spacewin       [ Scacco Matto / Space Win ]
+; { Reason 11 } ; speedatk       [ Speed Attack! (Japan) ]
+; { Reason 11 } ; speedrcr       [ Speed Racer ]
+; { Reason 11 } ; speedup        [ Speed Up (Version 1.20) ]
+; { Reason 11 } ; speglsht       [ Super Eagle Shot ]
+; { Reason 11 } ; spielbud       [ Spiel Bude (German) ]
+; { Reason 11 } ; spinkick       [ Hec's Spinkick ]
+; { Reason 11 } ; spuzbobl       [ Super Puzzle Bobble (V2.05O) ]
+; { Reason 11 } ; spuzboblj      [ Super Puzzle Bobble (V2.04J) ]
+; { Reason 11 } ; squaitsa       [ Squash (Itisa) ]
+; { Reason 11 } ; ssfindo        [ See See Find Out ]
+; { Reason 11 } ; ssipkr24       [ SSI Poker (v2.4) ]
+; { Reason 11 } ; ssipkr30       [ SSI Poker (v3.0) ]
+; { Reason 11 } ; ssipkr40       [ SSI Poker (v4.0) ]
+; { Reason 11 } ; sss            [ Steep Slope Sliders (JUET 981110 V1.000) ]
+; { Reason 11 } ; sstrike        [ Super Strike Bowling ]
+; { Reason 11 } ; starswep       [ Star Sweep (Japan, STP1/VER.A) ]
+; { Reason 11 } ; statriv4       [ Triv Four ]
+; { Reason 11 } ; strvmstr       [ Super Trivia Master ]
+; { Reason 11 } ; sundance       [ Sundance ]
+; { Reason 11 } ; superbwl       [ Super Bowl (Version 16.03B) ]
+; { Reason 11 } ; supertr3       [ Super Triv III ]
+; { Reason 11 } ; suplup         [ Super Lup Lup Puzzle / Zhuan Zhuan Puzzle (version 4.0 / 990518) ]
+; { Reason 11 } ; svg            [ S.V.G. - Spectral vs Generation (ver. 200) ]
+; { Reason 11 } ; sws95          [ Super World Stadium '95 (Japan) ]
+; { Reason 11 } ; sws98          [ Super World Stadium '98 (Japan, SS81/VER.A) ]
+; { Reason 11 } ; sws99          [ Super World Stadium '99 (Japan, SS91/VER.A3) ]
+; { Reason 11 } ; targetha       [ Target Hits (ver 1.0) ]
+; { Reason 11 } ; tenballs       [ Ten Balls (Ver 1.05) ]
+; { Reason 11 } ; tenthdeg       [ Tenth Degree (prototype) ]
+; { Reason 11 } ; tenup          [ Ten Up (compendium 17) ]
+; { Reason 11 } ; tenup3         [ Ten Up (compendium 3) ]
+; { Reason 11 } ; tetriskr       [ Tetris (bootleg of Mirrorsoft PC-XT Tetris version) ]
+; { Reason 11 } ; tetrsark       [ Tetris (D.R. Korea) ]
+; { Reason 11 } ; tgm2           [ Tetris the Absolute The Grand Master 2 ]
+; { Reason 11 } ; tgm2p          [ Tetris the Absolute The Grand Master 2 Plus ]
+; { Reason 11 } ; tictac         [ Tic Tac Trivia ]
+; { Reason 11 } ; tm             [ Touchmaster (v3.00 Euro) ]
+; { Reason 11 } ; tm2k           [ Touchmaster 2000 (v4.02 Standard) ]
+; { Reason 11 } ; tm2ka          [ Touchmaster 2000 (v4.00 Standard) ]
+; { Reason 11 } ; tm3k           [ Touchmaster 3000 (v5.02 Standard) ]
+; { Reason 11 } ; tm3ka          [ Touchmaster 3000 (v5.01 Standard) ]
+; { Reason 11 } ; tm4k           [ Touchmaster 4000 (v6.03 Standard) ]
+; { Reason 11 } ; tm4ka          [ Touchmaster 4000 (v6.02 Standard) ]
+; { Reason 11 } ; tm5k           [ Touchmaster 5000 (v7.10 Standard) ]
+; { Reason 11 } ; tm5ka          [ Touchmaster 5000 (v7.01 Standard) ]
+; { Reason 11 } ; tm5kca         [ Touchmaster 5000 (v7.10 California) ]
+; { Reason 11 } ; tm7k           [ Touchmaster 7000 (v8.04 Standard) ]
+; { Reason 11 } ; tm7ka          [ Touchmaster 7000 (v8.00 Standard) ]
+; { Reason 11 } ; tm7keval       [ Touchmaster 7000 (v8.1X Evaluation) ]
+; { Reason 11 } ; tm8k           [ Touchmaster 8000 (v9.04 Standard) ]
+; { Reason 11 } ; tm8k902        [ Touchmaster 8000 (v9.02 Standard) ]
+; { Reason 11 } ; tmdo           [ Touchmaster (v2.2-01 Standard) ]
+; { Reason 11 } ; tokimosh       [ Tokimeki Memorial Oshiete Your Heart (GE755 JAA) ]
+; { Reason 11 } ; tokimosp       [ Tokimeki Memorial Oshiete Your Heart Seal version PLUS (GE756 JAB) ]
+; { Reason 11 } ; tomcat         [ TomCat (prototype) ]
+; { Reason 11 } ; tomcatsw       [ TomCat (Star Wars hardware, prototype) ]
+; { Reason 11 } ; torus          [ Torus ]
+; { Reason 11 } ; tourtab2       [ Tournament Table (set 2) ]
+; { Reason 11 } ; tourtabl       [ Tournament Table (set 1) ]
+; { Reason 11 } ; trebltop       [ Treble Top (39-360-070) ]
+; { Reason 11 } ; trucocl        [ Truco Clemente ]
+; { Reason 11 } ; trvgns         [ Trivia Genius ]
+; { Reason 11 } ; trvhang        [ Trivia Hangup (Question Set 1) ]
+; { Reason 11 } ; trvquest       [ Trivia Quest ]
+; { Reason 11 } ; tryout         [ Pro Baseball Skill Tryout (Japan) ]
+; { Reason 11 } ; turbosub6      [ Turbo Sub (prototype rev. TSC6) ]
+; { Reason 11 } ; turbosub7      [ Turbo Sub (prototype rev. TSC7) ]
+; { Reason 11 } ; upscope        [ Up Scope ]
+; { Reason 11 } ; upyoural       [ Up Your Alley ]
+; { Reason 11 } ; usg182         [ Games V18.2 ]
+; { Reason 11 } ; vbowl          [ Virtua Bowling (World, V101XCM) ]
+; { Reason 11 } ; vbowlj         [ Virtua Bowling (Japan, V100JCM) ]
+; { Reason 11 } ; vf4cart        [ Virtua Fighter 4 (Cartridge) ]
+; { Reason 11 } ; victlapw       [ Ace Driver: Victory Lap (Rev. ADV2, World) ]
+; { Reason 11 } ; vmahjong       [ Virtual Mahjong (J 961214 V1.000) ]
+; { Reason 11 } ; vroulet        [ Vegas Roulette ]
+; { Reason 11 } ; wbbc97         [ Beach Festival World Championship 1997 ]
+; { Reason 11 } ; wcbowl140      [ World Class Bowling Tournament (v1.40) ]
+; { Reason 11 } ; wcvol95        [ World Cup Volley '95 (Japan v1.0) ]
+; { Reason 11 } ; wg3dh          [ Wayne Gretzky's 3D Hockey ]
+; { Reason 11 } ; windheat       [ Winding Heat (EAA, Euro v2.11) ]
+; { Reason 11 } ; windheatj      [ Winding Heat (JAA, Japan v2.11) ]
+; { Reason 11 } ; windheatu      [ Winding Heat (UBC, USA v2.22) ]
+; { Reason 11 } ; wondl96        [ Wonder League '96 (Korea) ]
+; { Reason 11 } ; wpksocv2       [ World PK Soccer V2 (ver 1.1) ]
+; { Reason 11 } ; xday2          [ X-Day 2 (Japan) ]
+; { Reason 11 } ; xiistag        [ XII Stag (V2.01J) ]
+; { Reason 11 } ; yukon          [ Yukon (version 2.0) ]
+; { Reason 11 } ; yukon1         [ Yukon (version 1.0) ]
+; { Reason 11 } ; znpwfv         [ Zen Nippon Pro-Wrestling Featuring Virtua (J 971123 V1.000) ]
+; { Reason 11 } ; zokuoten       [ Zoku Otenamihaiken (V2.03J) ]
+; { Reason 11 } ; zooo           [ Zooo (V2.01J) ]
+; { Reason 12 } ; aplatoon       [ Platoon V.?.? US ]
+; { Reason 12 } ; astron         [ Astron Belt ]
+; { Reason 12 } ; astronp        [ Astron Belt (Pioneer LDV1000) ]
+; { Reason 12 } ; cliffhgra      [ Cliff Hanger (Alt) ]
+; { Reason 12 } ; cobra          [ Cobra Command (Data East LD) ]
+; { Reason 12 } ; cobraseg       [ Cobra Command (Sega LaserDisc Hardware) ]
+; { Reason 12 } ; crimep2        [ Crime Patrol 2: Drug Wars v1.3 ]
+; { Reason 12 } ; crimep211      [ Crime Patrol 2: Drug Wars v1.1 ]
+; { Reason 12 } ; crimepat       [ Crime Patrol v1.4 ]
+; { Reason 12 } ; dlair          [ Dragon's Lair (US Rev. F2) ]
+; { Reason 12 } ; dlaira         [ Dragon's Lair (US Rev. A, Pioneer PR-7820) ]
+; { Reason 12 } ; dlairb         [ Dragon's Lair (US Rev. B, Pioneer PR-7820) ]
+; { Reason 12 } ; dlairc         [ Dragon's Lair (US Rev. C, Pioneer PR-7820) ]
+; { Reason 12 } ; dlaird         [ Dragon's Lair (US Rev. D, Pioneer LD-V1000) ]
+; { Reason 12 } ; dlaire         [ Dragon's Lair (US Rev. E) ]
+; { Reason 12 } ; dlairf         [ Dragon's Lair (US Rev. F) ]
+; { Reason 12 } ; dleuro         [ Dragon's Lair (European) ]
+; { Reason 12 } ; dlital         [ Dragon's Lair (Italian) ]
+; { Reason 12 } ; esh            [ Esh's Aurunmilla (set 1) ]
+; { Reason 12 } ; esha           [ Esh's Aurunmilla (Set 2) ]
+; { Reason 12 } ; eshb           [ Esh's Aurunmilla (Set 3) ]
+; { Reason 12 } ; fastdraw       [ Fast Draw Showdown v1.3 ]
+; { Reason 12 } ; galaxyr        [ Galaxy Ranger ]
+; { Reason 12 } ; galaxyrp       [ Galaxy Ranger (Pioneer LDV1000) ]
+; { Reason 12 } ; gallgall       [ Gallagher's Gallery v2.2 ]
+; { Reason 12 } ; goaltogo       [ Goal To Go ]
+; { Reason 12 } ; gpworld        [ GP World ]
+; { Reason 12 } ; istellar       [ Interstellar Laser Fantasy ]
+; { Reason 12 } ; lastbh         [ The Last Bounty Hunter v0.06 ]
+; { Reason 12 } ; lgp            [ Laser Grand Prix ]
+; { Reason 12 } ; maddog         [ Mad Dog McCree v2.03 board rev.B ]
+; { Reason 12 } ; maddog2        [ Mad Dog II: The Lost Gold v2.04 ]
+; { Reason 12 } ; maddog21       [ Mad Dog II: The Lost Gold v1.0 ]
+; { Reason 12 } ; maddog22       [ Mad Dog II: The Lost Gold v2.02 ]
+; { Reason 12 } ; maddoga        [ Mad Dog McCree v1C board rev.A ]
+; { Reason 12 } ; saeuro         [ Space Ace (European) ]
+; { Reason 12 } ; sblazerp       [ Star Blazer (Pioneer LDV1000) ]
+; { Reason 12 } ; spaceaa        [ Space Ace (US Rev. A) ]
+; { Reason 12 } ; spaceaa2       [ Space Ace (US Rev. A2) ]
+; { Reason 12 } ; spaceace       [ Space Ace (US Rev. A3) ]
+; { Reason 12 } ; spacepir       [ Space Pirates v2.2 ]
+; { Reason 12 } ; superdq        [ Super Don Quix-ote (Long Scenes) ]
+; { Reason 12 } ; superdqa       [ Super Don Quix-ote (Short Scenes, Alt) ]
+; { Reason 12 } ; superdqs       [ Super Don Quix-ote (Short Scenes) ]
+; { Reason 12 } ; thayers        [ Thayer's Quest ]
+; { Reason 12 } ; thayersa       [ Thayer's Quest (Alternate Set) ]
+; { Reason 12 } ; wsjr           [ Who Shot Johnny Rock? v1.6 ]
+; { Reason 12 } ; wsjr15         [ Who Shot Johnny Rock? v1.5 ]
+; { Reason 12 } ; zortonbr       [ Zorton Brothers (Los Justicieros) ]
+
+------------------------------------------------------------------------------
+              SECTION 15     General list of work to be done
+------------------------------------------------------------------------------
+
+Old List:-
+----------
+
+Don't expect this list to change too much - there's more pressing issues for
+me to deal with normally - I do have a crack at them occasionally.
+
+Look at replicating Mania Challenge cheats for The Main Event
+The Return of Ishtar needs more work - present cheats has problems in b12 ...
+More codes for 88 Games
+I, Robot more codes needed
+Baluba-louk no Densetsu more codes?
+Knock Out/Triple Punch - Look at the invincibility cheats
+My Hero - Round Select codes
+Syougi No Tatsujin - more cheats?
+Flash Gal - check for level select cheats
+Cosmo Gang the Video - check out both versions unsure which is NOW the original
+one the cheat was made for.
+Look at Fatal Fury 4 cheats - rename add more?
+Body Slam - room for lots more cheats, see other wrestling games for possible cheats
+More cheats for Big Pro Wrestling! needed
+More cheats for Yosaku To Donbee
+Add Select score cheats for the Super Sidekicks series of games
+Do Infinite Health, Infinite Ammo, Always have Gun/Get Gun Now! cheats for all levels
+ and both players for the game Top Hunter
+Ultraman look at cheats and check....problems encountered
+Rename 'type' cheats for dfeveron, requires better descriptions
+More cheats for invad2ct - Space Invaders II
+Missing PL2 cheats for Ghox to be found and all cheats to be cleaned up
+More cheats for Snow Bros. 2
+Air Buster - possible trigger cheat missing from Side shot, Powerball & B cheats. Investigate
+Soldam (Japan) - possibility of a lot more colour related cheats, + needs some other cheats
+U.S. Classic - more cheats required, PL2 cheats not yet possible! (beta 1)
+raphero game is a clone, but more cheats here than for the others  bigbang&tdragon2 (maybe the raphero cheats can be replicated)
+tmekprot - there's more cheats for tmek, though the cheats don't seem to exist for tmekprot (look into program code)
+mslug4 & clone - look at cheats, weapon cheats appear not to work properly
+
+
+Newest List:-
+-----------------------------------------------------------------------
+Update the remaining [ ] format comment cheats to the separated by ---- format [COMPLETE AS FAR AS NEEDED]
+Fix any flickering invincibility cheats to stop the flickering using ROM cheats [AS AND WHEN]
+Convert single byte multi-part cheats to poke 2,4 bytes [AS AND WHEN]
+Convert cheats that are poking the same location into list cheats  + poss. dropping Now! duplicated cheats [AS AND WHEN]
+Look at the games with no cheats in supergm3
+
+
+


### PR DESCRIPTION
The MAME 0.139 cheat engine uses a different metadata format than the older MAME cores. 0.139 parses `cheat.zip` file directly.

edit: Added hiscore.dat to the PR to enable high score saving