### PR TITLE
Add core option for "core provided aspect ratio", can use PAR or DAR.  like the fbalpha approach

### DIFF
--- a/src/osd/retro/retromain.c
+++ b/src/osd/retro/retromain.c
@@ -46,7 +46,9 @@ bool hide_nagscreen = false;
 bool hide_gameinfo = false;
 bool hide_warnings = false;
 //
+static void update_geometry();
 static unsigned int turbo_enable, turbo_state, turbo_delay = 5;
+static bool set_par = false; 
 
 static void extract_basename(char *buf, const char *path, size_t size)
 {

--- a/src/osd/retro/retromapper.c
+++ b/src/osd/retro/retromapper.c
@@ -52,6 +52,7 @@ void retro_set_environment(retro_environment_t cb)
       { "mame_current_skip_nagscreen", "Hide nag screen; disabled|enabled" },
       { "mame_current_skip_gameinfo", "Hide game info screen; disabled|enabled" },
       { "mame_current_skip_warnings", "Hide warning screen; disabled|enabled" },
+      { "mame_current_aspect_ratio", "Core provided aspect ratio; DAR|PAR" },
       { "mame_current_turbo_button", "Enable autofire; disabled|button 1|button 2|R2 to button 1 mapping|R2 to button 2 mapping" },
       { "mame_current_turbo_delay", "Set autofire pulse speed; medium|slow|fast" },
       { NULL, NULL },
@@ -65,6 +66,8 @@ void retro_set_environment(retro_environment_t cb)
 static void check_variables(void)
 {
    struct retro_variable var = {0};
+   bool tmp_ar = set_par;
+	
    var.key = "mame_current_mouse_enable";
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
@@ -149,7 +152,18 @@ static void check_variables(void)
 	else
 		turbo_delay = 3;
    }
-	
+
+   var.key = "mame_current_aspect_ratio";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      	if (!strcmp(var.value, "PAR"))
+		set_par = true;
+	else
+		set_par = false;
+   }
+
+   if (tmp_ar != set_par)
+	update_geometry();
 }
 
 unsigned retro_api_version(void)
@@ -185,7 +199,7 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
    info->geometry.max_width    = 1024;
    info->geometry.max_height   = 768;
 	
-   float display_ratio 	= vertical ? (float)rthe / (float)rtwi : (float)rtwi / (float)rthe;
+   float display_ratio 	= set_par ? (vertical ? (float)rthe / (float)rtwi : (float)rtwi / (float)rthe) : (vertical ? 3.0f / 4.0f : 4.0f / 3.0f);
    info->geometry.aspect_ratio = display_ratio;
    write_log("display aspect ratio = %f \n", display_ratio);
 

--- a/src/osd/retro/retroosd.c
+++ b/src/osd/retro/retroosd.c
@@ -103,7 +103,8 @@ void osd_update(running_machine *machine,int skip_redraw)
          rthe=minheight;
          topw=minwidth;
 
-	 update_geometry();
+	 if (set_par)
+		update_geometry();
       }
 
       if(videoapproach1_enable){


### PR DESCRIPTION
Some games in "PAR - pixel aspect ratio" mode , the screen ratio is strange and distorted . such as CPS1/2 (384 * 224 , 12:7), also includes konami and nmk some games,  DAR mode should be better at this time.
