### PR TITLE
Fix the problem of gameplay speed too slow in Dream Soccer '94 (M107 version)

### DIFF
--- a/src/mame/drivers/m107.c
+++ b/src/mame/drivers/m107.c
@@ -214,7 +214,8 @@ static INPUT_PORTS_START( m107_2player )
 	PORT_BIT( 0x0010, IP_ACTIVE_LOW, IPT_SERVICE1 )
 	PORT_BIT( 0x0020, IP_ACTIVE_LOW, IPT_SERVICE )
 	PORT_BIT( 0x0040, IP_ACTIVE_LOW, IPT_UNUSED )
-	PORT_BIT( 0x0080, IP_ACTIVE_LOW, IPT_VBLANK )
+	/* This is sprite flag on IREM M92, if this is active low, then "Dream Soccer'94" is unplayably slow . */
+	PORT_BIT( 0x0080, IP_ACTIVE_HIGH, IPT_VBLANK )
 
 	/* DIP switch bank 3 */
 	PORT_DIPUNKNOWN_DIPLOC( 0x0100, 0x0100, "SW3:1" )


### PR DESCRIPTION
form mame 0.140u3

![dsoccr94-171207-170037](https://user-images.githubusercontent.com/24326506/33708847-90b545de-db76-11e7-946e-333f3dbc6523.png)
