### PR TITLE
Refresh rate should not always be 60.0

### DIFF
--- a/src/osd/retro/retromain.c
+++ b/src/osd/retro/retromain.c
@@ -48,7 +48,8 @@ bool hide_warnings = false;
 //
 static void update_geometry();
 static unsigned int turbo_enable, turbo_state, turbo_delay = 5;
-static bool set_par = false; 
+static bool set_par = false;
+static double refresh_rate = 60.0;
 
 static void extract_basename(char *buf, const char *path, size_t size)
 {

--- a/src/osd/retro/retromapper.c
+++ b/src/osd/retro/retromapper.c
@@ -230,10 +230,27 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
 	
    float display_ratio 	= set_par ? (vertical ? (float)rthe / (float)rtwi : (float)rtwi / (float)rthe) : (vertical ? 3.0f / 4.0f : 4.0f / 3.0f);
    info->geometry.aspect_ratio = display_ratio;
-   write_log("display aspect ratio = %f \n", display_ratio);
 
-   info->timing.fps            = 60;
+   info->timing.fps            = refresh_rate;
    info->timing.sample_rate    = 48000.0;
+
+#if 0	/* Test */
+	int common_factor = 1;
+	if (set_par)
+	{
+		int temp_width = rtwi;
+		int temp_height = rthe;
+		while (temp_width != temp_height)
+		{
+			if (temp_width > temp_height)
+				temp_width -= temp_height;
+			else
+				temp_height -= temp_width;
+		}
+		common_factor = temp_height;
+	}
+	write_log("Current aspect ratio = %d : %d and screen refresh rate = %f\n", set_par ? vertical ? rthe / common_factor : rtwi / common_factor : vertical ? 3 : 4, set_par ? vertical ? rtwi / common_factor : rthe / common_factor : vertical ? 4 : 3, refresh_rate);
+#endif
 }
 
 void retro_init (void)

--- a/src/osd/retro/retroosd.c
+++ b/src/osd/retro/retroosd.c
@@ -76,6 +76,12 @@ void osd_update(running_machine *machine,int skip_redraw)
          minwidth=1024;minheight=768;
       }
 
+      if (FirstTimeUpdate == 2)
+      {
+         FirstTimeUpdate++;
+	 refresh_rate = (machine->primary_screen == NULL) ? screen_device::k_default_frame_rate : ATTOSECONDS_TO_HZ(machine->primary_screen->frame_period().attoseconds);
+      }
+
       if (FirstTimeUpdate == 1) {
 
          FirstTimeUpdate++;			
@@ -94,7 +100,6 @@ void osd_update(running_machine *machine,int skip_redraw)
          gamRot = (ROT90  == orient) ? 3 : gamRot;
 
          prep_retro_rotation(gamRot);
-
       }
 
       if (minwidth != rtwi || minheight != rthe ){
@@ -103,14 +108,13 @@ void osd_update(running_machine *machine,int skip_redraw)
          rthe=minheight;
          topw=minwidth;
 
-	 if (set_par)
-		update_geometry();
+	 update_geometry();
       }
-
+/*    No need
       if(videoapproach1_enable){
          rtwi=topw=1024;
          rthe=768;
-      }
+      } */
 
       // make that the size of our target
       render_target_set_bounds(our_target,rtwi,rthe, 0);


### PR DESCRIPTION
test log : 
Parameters: 
Executing: /opt/retropie/emulators/retroarch/bin/retroarch -L /opt/retropie/libretrocores/lr-mame2010/mame2010_libretro.so --config /opt/retropie/configs/mame-mame4all/retroarch.cfg "/home/pi/RetroPie/roms/mame-mame4all/misc/toki.zip" --appendconfig /dev/shm/retroarch.cfg
value: disabled
value: disabled
SOURCE FILE: src/mame/drivers/toki.c
PARENT: 0
NAME: toki
DESCRIPTION: Toki (World, set 1)
YEAR: 1989
MANUFACTURER: TAD Corporation
value: disabled
value: disabled
value: disabled
value: disabled
value: disabled
value: enabled
value: disabled
value: disabled
Current aspect ratio = 4 : 3 and screen refresh rate = 60.000000
gamePath=/home/pi/RetroPie/roms/mame-mame4all/misc  gameName=toki
toki              "Toki (World, set 1)"  rot=0 
creating frontend... game = toki
executing frontend... params:16
mamemini 
-joystick 
-noautoframeskip 
-samplerate 
32000 
-sound 
-contrast 
1.0 
-brightness 
1.0 
-gamma 
1.0 
-rompath 
/home/pi/RetroPie/roms/mame-mame4all/misc 
-mouse 
toki 
machine screen orientation: HORIZONTAL 
Rotation:0
osd init done
game screen  w=256  h=224  rowPixels=256
Rotation:0

Current aspect ratio = 8 : 7 and screen refresh rate = 59.610000
Current aspect ratio = 4 : 3 and screen refresh rate = 59.610000
Current aspect ratio = 8 : 7 and screen refresh rate = 59.610000
Res change: old(256, 224) new(1024, 768) 256
Current aspect ratio = 4 : 3 and screen refresh rate = 59.610000
Res change: old(1024, 768) new(256, 224) 1024
Current aspect ratio = 8 : 7 and screen refresh rate = 59.610000
Retro unload_game
Retro DeInit