### PR TITLE
Update mame.ini

### DIFF
--- a/mame.ini
+++ b/mame.ini
@@ -7,29 +7,6 @@ readconfig                1
 writeconfig               0
 
 #
-# CORE SEARCH PATH OPTIONS
-rompath                   roms
-samplepath                samples
-artpath                   artwork
-ctrlrpath                 ctrlr
-inipath                   .;ini
-fontpath                  .
-cheatpath                 cheat
-crosshairpath             crosshair
-
-#
-# CORE OUTPUT DIRECTORY OPTIONS
-#
-cfg_directory             cfg
-nvram_directory           nvram
-memcard_directory         memcard
-input_directory           inp
-state_directory           sta
-snapshot_directory        snap
-diff_directory            diff
-comment_directory         comments
-
-#
 # CORE STATE/PLAYBACK OPTIONS
 #
 state                     
@@ -50,7 +27,6 @@ burnin                    0
 autoframeskip             1
 frameskip                 0
 seconds_to_run            0
-throttle                  1
 sleep                     1
 speed                     1.0
 refreshspeed              0


### PR DESCRIPTION
These legacy options are managed via libretro now. They don't function in the mame.ini.