### PR TITLE
attempt to fix ps3 build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ else ifeq ($(platform), ps3)
    TARGETLIB := $(TARGET_NAME)_libretro_$(platform).a
    CC = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-gcc.exe
    AR = $(CELL_SDK)/host-win32/ppu/bin/ppu-lv2-ar.exe
-   CFLAGS += -DBLARGG_BIG_ENDIAN=1 -D__ppc__
+   CFLAGS += -DBLARGG_BIG_ENDIAN=1 -D__ppc__ -DPS3_LIBRETRO
 	STATIC_LINKING = 1
 	BIGENDIAN=1
 	LIBS += -lstdc++ -lpthread

--- a/src/emu/state.h
+++ b/src/emu/state.h
@@ -24,7 +24,7 @@
 #elif defined(IOS)
 #include <tr1/type_traits>
 #define DEF_NAMESPACE std::tr1
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && !defined(PS3_LIBRETRO)
 #include <tr1/type_traits>
 #define DEF_NAMESPACE std::tr1
 #endif


### PR DESCRIPTION
This would just skip the line where the build is stopping for PS3. Not a very sophisticated attempt.