### PR TITLE
default BUILD_BIN2C to disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 NATIVE :=0
 
 UNAME=$(shell uname -a)
-BUILD_BIN2C ?= 1
+BUILD_BIN2C ?= 0
 
 ifeq ($(platform),)
 platform = unix


### PR DESCRIPTION
per suggestion by @retro-wertz to only execute bin2c manually when needed, at least until there is a more sophisticated approach in the makefile