### PR TITLE
Misc Build Fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,8 @@ include:
     file: '/linux-x64.yml'
   - project: 'libretro-infrastructure/ci-templates'
     file: '/windows-x64-mingw.yml'
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/android-jni.yml'
 
 stages:
   - build-prepare
@@ -32,3 +34,19 @@ libretro-build-windows-x64:
     AR:       x86_64-w64-mingw32-ar
     NATIVELD: x86_64-w64-mingw32-ld
     LD:       x86_64-w64-mingw32-ld
+
+# Android
+android-armeabi-v7a:
+  extends:
+    - .core-defs
+    - .libretro-android-jni-armeabi-v7a
+
+android-arm64-v8a:
+  extends:
+    - .core-defs
+    - .libretro-android-jni-arm64-v8a
+
+android-x86_64:
+  extends:
+    - .core-defs
+    - .libretro-android-jni-x86_64

--- a/Makefile
+++ b/Makefile
@@ -107,16 +107,16 @@ endif
 UNAME=$(shell uname -m)
 
 ifeq ($(firstword $(filter x86_64,$(UNAME))),x86_64)
-PTR64 = 1
+PTR64 ?= 1
 endif
 ifeq ($(firstword $(filter amd64,$(UNAME))),amd64)
-PTR64 = 1
+PTR64 ?= 1
 endif
 ifeq ($(firstword $(filter ppc64,$(UNAME))),ppc64)
-PTR64 = 1
+PTR64 ?= 1
 endif
 ifneq (,$(findstring mingw64-w64,$(PATH)))
-PTR64=1
+PTR64 ?= 1
 endif
 ifneq (,$(findstring Power,$(UNAME)))
 BIGENDIAN=1

--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ else ifeq ($(platform), wiiu)
    CC = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
    CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-   COMMONFLAGS += -DGEKKO -mwup -mcpu=750 -meabi -mhard-float -D__POWERPC__ -D__ppc__ -DWORDS_BIGENDIAN=1 -malign-natural 
+   COMMONFLAGS += -DGEKKO -mcpu=750 -meabi -mhard-float -D__POWERPC__ -D__ppc__ -DWORDS_BIGENDIAN=1 -malign-natural 
    COMMONFLAGS += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int -fsingle-precision-constant -mno-bit-align
    COMMONFLAGS += -DHAVE_STRTOUL -DBIGENDIAN=1 -DWIIU -DOLEFIX
    DEFS       += -DMSB_FIRST

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -4,6 +4,8 @@ define uniq
 	$(if $1,$(firstword $1) $(call uniq,$(filter-out $(firstword $1),$1)))
 endef
 
+DEFS :=
+
 TARGET := mame
 OSD    := retro
 
@@ -18,6 +20,16 @@ LIBUTIL  := $(OBJ)/libutil.a
 LIBOCORE := $(OBJ)/libocore.a
 LIBOSD   := $(OBJ)/libosd.a
 
+
+ifneq ($(filter $(TARGET_ARCH_ABI), arm64-v8a x86_64),)
+  PTR64 := 1
+  DEFS  += -DPTR64
+endif
+
+ifeq ($(filter $(TARGET_ARCH_ABI), x86 x86_64),)
+  FORCE_DRC_C_BACKEND := 1
+endif
+
 include $(CORE_DIR)/Makefile.common
 
 COREFLAGS := $(DEFS) $(INCFLAGS)
@@ -26,7 +38,7 @@ COREFLAGS += -DCRLF=2 -DINLINE="static inline" -Wno-c++11-narrowing -Wno-reserve
 # For testing only, remove before PR
 COREFLAGS += -Wno-implicit-exception-spec-mismatch -Wno-inline-new-delete -Wno-tautological-undefined-compare
 
-ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+ifneq ($(filter $(TARGET_ARCH_ABI), armeabi-v7a arm64-v8a),)
   COREFLAGS += -DARM_ENABLED
 endif
 

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,2 +1,2 @@
-APP_ABI := armeabi-v7a
+APP_ABI := armeabi-v7a arm64-v8a x86_64
 APP_STL := c++_static


### PR DESCRIPTION
These commits have three main effects:

Fixes wii-u compile by removing an obsolete flag
Fixes 32-bit Linux and Windows compile by allowing the PTR64 makefile flag to be overridden
Fixes android arm64 and x86_64 compile and enables android builds