### PR TITLE
add webOS to Makefile / CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,7 +71,11 @@ include:
     file: '/tvos-arm64.yml'
 
   #################################### MISC ##################################
-    
+
+  # webOS 32-bit (LGTV)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/webos-make.yml'
+
 # Stages for building
 stages:
   - build-prepare
@@ -196,4 +200,11 @@ libretro-build-ios9:
 libretro-build-tvos-arm64:
   extends:
     - .libretro-tvos-arm64-make-default
+    - .core-defs
+
+#################################### MISC ##################################
+# webOS 32-bit
+libretro-build-webos-armv7a:
+  extends:
+    - .libretro-webos-armv7a-make-default
     - .core-defs

--- a/Makefile
+++ b/Makefile
@@ -541,7 +541,10 @@ endif
 	DEFS += -DX64_WINDOWS_ABI
 endif
 
-
+ifneq (,$(or $(findstring webos,$(CROSS_COMPILE)),$(findstring starfish,$(CROSS_COMPILE))))
+  FORCE_DRC_C_BACKEND = 1
+  PTR64 = 0
+endif
 
 ifeq ($(ALIGNED),1)
 	PLATCFLAGS += -DALIGN_INTS -DALIGN_SHORTS 


### PR DESCRIPTION
Couple of minor changes needed to compile for webOS.

Checks for both the unofficial SDK (buildroot-nc4) and official SDK (starfish).