### PR TITLE
add linux-aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,6 +39,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
 
+  # Linux 64-bit (ARM)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # MacOS 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-x64.yml'
@@ -124,7 +128,13 @@ libretro-build-linux-i686:
     AR:       ar
     NATIVELD: ld
     LD:       ld
-    
+
+# Linux 64-bit (ARM)
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
+    - .core-defs
+
 # MacOS 64-bit
 libretro-build-osx-x64:
   extends:

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,9 @@ endif
 ifeq ($(firstword $(filter arm64,$(UNAME))),arm64)
 PTR64 ?= 1
 endif
+ifeq ($(firstword $(filter aarch64,$(UNAME))),aarch64)
+PTR64 ?= 1
+endif
 ifneq (,$(findstring Power,$(UNAME)))
 BIGENDIAN=1
 endif


### PR DESCRIPTION
Add linux-aarch64 CI build job.

Also adds `aarch64` to the PTR64 detection in the Makefile — `uname -m` returns `aarch64` on Linux, not `arm64`.