### PR TITLE
Fix the x86 inline asm clobber, and build the Android x86 ABI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -184,6 +184,12 @@ android-x86_64:
     - .libretro-android-jni-x86_64
     - .core-defs
 
+# Android 32-bit x86
+android-x86:
+  extends:
+    - .libretro-android-jni-x86
+    - .core-defs
+
 # iOS
 libretro-build-ios-arm64:
   extends:

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,2 +1,2 @@
-APP_ABI := armeabi-v7a arm64-v8a x86_64
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 APP_STL := c++_static

--- a/src/emu/eigccx86.h
+++ b/src/emu/eigccx86.h
@@ -44,7 +44,7 @@ _mul_32x32(int32_t a, int32_t b)
 		: [result] "=A" (result)	/* result in edx:eax */
 		: [a]      "%a"  (a)		/* 'a' should also be in eax on entry */
 		, [b]      "rm"  (b)		/* 'b' can be memory or register */
-		: "%cc"						/* Clobbers condition codes */
+		: "cc" 						/* Clobbers condition codes */
 	);
 
 	return result;
@@ -70,7 +70,7 @@ _mulu_32x32(uint32_t a, uint32_t b)
 		: [result] "=A" (result)	/* result in edx:eax */
 		: [a]      "%a"  (a)		/* 'a' should also be in eax on entry */
 		, [b]      "rm"  (b)		/* 'b' can be memory or register */
-		: "%cc"						/* Clobbers condition codes */
+		: "cc" 						/* Clobbers condition codes */
 	);
 
 	return result;


### PR DESCRIPTION
`android-x86` is the one ABI missing from this core: `armeabi-v7a`, `arm64-v8a` and `x86_64` are all built and green. It turned out not to be a CI omission — the ABI does not compile, for one character.

```
src/emu/eigccx86.h:47:5: error: unknown register name '%cc' in asm
   47 |    : "%cc"      /* Clobbers condition codes */
src/emu/eigccx86.h:73:5: error: unknown register name '%cc' in asm
```

The clobber is spelled `"%cc"`. gcc accepts that; clang does not, and the NDK is clang, so an x86 build stops at the first file that reaches `eminline.h`. `armeabi-v7a` is 32-bit too and never notices, because it does not include the x86 header at all.

Worth noting that this looks like a slip rather than a decision: the other twenty-one clobbers in that same file already say `"cc"`, and so does current MAME upstream.

With those two lines fixed, `ndk-build APP_ABI=x86` builds the core through to `libs/x86/libretro.so`. Three commits:

1. the `eigccx86.h` fix
2. `jni/Application.mk`: add `x86` to `APP_ABI`, which listed only three of the four ABIs the CI builds — so a local `ndk-build` produced a different set from the buildbot's
3. the `android-x86` job

Built on a GitHub runner with NDK 29.0.14206865. The fix itself is not Android-specific: any clang-built 32-bit x86 target hits the same line, so a `linux-i686` built with clang instead of gcc would have too.
